### PR TITLE
Major improvements

### DIFF
--- a/environments.py
+++ b/environments.py
@@ -321,30 +321,3 @@ class SelfLocalizeEnv(PlaceMazeEnv):
         stepOutput = super().step(action)
         self._visitCounts[self._agentLocation[0]][self._agentLocation[1]] += 1
         return stepOutput
-
-
-class MemoryMazeEnv(FoggedMazeEnv):
-    def __init__(self, config=None):
-        super().__init__(config)
-        visualObsSize = self._visualRange * 2 + 1
-        self._lastObs = None
-        self.observation_space = gym.spaces.Box(
-            0, self._mazeSize, (visualObsSize**2 * 3 * 2,)
-        )
-
-    def reset(self, *, seed: Optional[int] = None, options: Optional[dict] = None):
-        super().reset(seed=seed, options=options)
-        self._lastObs = super()._getObs()
-        return self._getObs(), self._get_info()
-
-    def step(self, action):
-        self._lastObs = super()._getObs()
-        return super().step(action)
-
-    def _getObs(self):
-        vision = super()._getObs()
-        previousVision = self._lastObs if self._lastObs is not None else vision
-        return np.concatenate(
-            [vision.flatten(), previousVision.flatten()],
-            dtype=np.float32,
-        )

--- a/environments.py
+++ b/environments.py
@@ -329,7 +329,7 @@ class MemoryMazeEnv(FoggedMazeEnv):
         visualObsSize = self._visualRange * 2 + 1
         self._lastObs = None
         self.observation_space = gym.spaces.Box(
-            0, self._mazeSize, (visualObsSize**2 * 3 * 2 + 5,)
+            0, self._mazeSize, (visualObsSize**2 * 3 * 2,)
         )
 
     def reset(self, *, seed: Optional[int] = None, options: Optional[dict] = None):
@@ -344,9 +344,7 @@ class MemoryMazeEnv(FoggedMazeEnv):
     def _getObs(self):
         vision = super()._getObs()
         previousVision = self._lastObs if self._lastObs is not None else vision
-        action = np.zeros([5])
-        action[self._actionTaken] = 1
         return np.concatenate(
-            [vision.flatten(), previousVision.flatten(), action],
+            [vision.flatten(), previousVision.flatten()],
             dtype=np.float32,
         )

--- a/environments.py
+++ b/environments.py
@@ -329,7 +329,7 @@ class MemoryMazeEnv(FoggedMazeEnv):
         visualObsSize = self._visualRange * 2 + 1
         self._lastObs = None
         self.observation_space = gym.spaces.Box(
-            0, self._mazeSize, (visualObsSize**2 * 3 * 2,)
+            0, self._mazeSize, (visualObsSize**2 * 3 * 2 + 5,)
         )
 
     def reset(self, *, seed: Optional[int] = None, options: Optional[dict] = None):
@@ -344,7 +344,9 @@ class MemoryMazeEnv(FoggedMazeEnv):
     def _getObs(self):
         vision = super()._getObs()
         previousVision = self._lastObs if self._lastObs is not None else vision
+        action = np.zeros([5])
+        action[self._actionTaken] = 1
         return np.concatenate(
-            [vision.flatten(), previousVision.flatten()],
+            [vision.flatten(), previousVision.flatten(), action],
             dtype=np.float32,
         )

--- a/learners/ppo_grid_learner.py
+++ b/learners/ppo_grid_learner.py
@@ -79,8 +79,27 @@ class PPOTorchLearnerWithSelfPredLoss(PPOTorchLearner):
             batch=batch,
             fwd_out=fwd_out,
         )
+
+        # Action Awareness Loss
+        obs = batch["obs"]
+        action = obs[:, :, -5:][lossMask]
+        predictedActionLogit = fwd_out["predictedAction"][lossMask]
+        actionAwarenessLoss = torch.nn.functional.cross_entropy(
+            predictedActionLogit, action
+        )
+        self.metrics.log_value(
+            key=(module_id, "orthonormal_loss"),
+            value=orthonormalLoss.cpu().detach().numpy(),
+            window=100,
+        )
+        self.metrics.log_value(
+            key=(module_id, "action_awareness_loss"),
+            value=actionAwarenessLoss.cpu().detach().numpy(),
+            window=100,
+        )
+
         if config.learner_config_dict.get("self_localize"):
-            total_loss = placeLoss + orthonormalLoss
+            total_loss = placeLoss + orthonormalLoss + actionAwarenessLoss
         self.metrics.log_value(
             key=(module_id, "prediction_error"),
             value=predictionError.cpu().detach().numpy(),

--- a/learners/ppo_grid_learner.py
+++ b/learners/ppo_grid_learner.py
@@ -80,32 +80,14 @@ class PPOTorchLearnerWithSelfPredLoss(PPOTorchLearner):
             fwd_out=fwd_out,
         )
 
-        # Vision Loss
-        obs: torch.Tensor = batch["obs"]
-        module = self.module[module_id]
-        vision = (
-            obs[lossMask]
-            .reshape([-1, module.inputSize, module.inputSize, 3])[:, :, :, 0]
-            .flatten(1)
-            .to(torch.float32)
-        )
-        predictedObs = fwd_out["predictedObs"][lossMask]
-        visionReconstructionLoss = torch.nn.functional.binary_cross_entropy(
-            predictedObs, vision
-        )
         self.metrics.log_value(
             key=(module_id, "orthonormal_loss"),
             value=orthonormalLoss.cpu().detach().numpy(),
             window=100,
         )
-        self.metrics.log_value(
-            key=(module_id, "vision_reconstruction_loss"),
-            value=visionReconstructionLoss.cpu().detach().numpy(),
-            window=100,
-        )
 
         if config.learner_config_dict.get("self_localize"):
-            total_loss = placeLoss + orthonormalLoss + visionReconstructionLoss
+            total_loss = placeLoss + orthonormalLoss
         self.metrics.log_value(
             key=(module_id, "prediction_error"),
             value=predictionError.cpu().detach().numpy(),

--- a/learners/ppo_grid_learner.py
+++ b/learners/ppo_grid_learner.py
@@ -23,7 +23,7 @@ class PPOTorchLearnerWithSelfPredLoss(PPOTorchLearner):
         placeCells = None
         for name, weight in parameters:
             if name == "moduleProjector.weight":
-                P = weight
+                P = torch.softmax(weight, dim=1)
                 M = P.shape[0] // 2
                 P_blocks = P.view(M, 2, -1)
                 G = torch.einsum("mid,njd->mnij", P_blocks, P_blocks)

--- a/learners/ppo_grid_learner.py
+++ b/learners/ppo_grid_learner.py
@@ -80,12 +80,18 @@ class PPOTorchLearnerWithSelfPredLoss(PPOTorchLearner):
             fwd_out=fwd_out,
         )
 
-        # Action Awareness Loss
-        obs = batch["obs"]
-        action = obs[:, :, -5:][lossMask]
-        predictedActionLogit = fwd_out["predictedAction"][lossMask]
-        actionAwarenessLoss = torch.nn.functional.cross_entropy(
-            predictedActionLogit, action
+        # Vision Loss
+        obs: torch.Tensor = batch["obs"]
+        module = self.module[module_id]
+        visionSize = module.inputSize**2 * 3
+        vision = (
+            obs[:, :, visionSize:][lossMask]
+            .reshape([-1, module.inputSize, module.inputSize, 3])[:, :, :, 0]
+            .flatten(1)
+        )
+        predictedObs = fwd_out["predictedObs"][lossMask]
+        visionReconstructionLoss = torch.nn.functional.binary_cross_entropy(
+            predictedObs, vision
         )
         self.metrics.log_value(
             key=(module_id, "orthonormal_loss"),
@@ -93,13 +99,13 @@ class PPOTorchLearnerWithSelfPredLoss(PPOTorchLearner):
             window=100,
         )
         self.metrics.log_value(
-            key=(module_id, "action_awareness_loss"),
-            value=actionAwarenessLoss.cpu().detach().numpy(),
+            key=(module_id, "vision_reconstruction_loss"),
+            value=visionReconstructionLoss.cpu().detach().numpy(),
             window=100,
         )
 
         if config.learner_config_dict.get("self_localize"):
-            total_loss = placeLoss + orthonormalLoss + actionAwarenessLoss
+            total_loss = placeLoss + orthonormalLoss + visionReconstructionLoss
         self.metrics.log_value(
             key=(module_id, "prediction_error"),
             value=predictionError.cpu().detach().numpy(),

--- a/learners/ppo_grid_learner.py
+++ b/learners/ppo_grid_learner.py
@@ -83,11 +83,11 @@ class PPOTorchLearnerWithSelfPredLoss(PPOTorchLearner):
         # Vision Loss
         obs: torch.Tensor = batch["obs"]
         module = self.module[module_id]
-        visionSize = module.inputSize**2 * 3
         vision = (
-            obs[:, :, visionSize:][lossMask]
+            obs[lossMask]
             .reshape([-1, module.inputSize, module.inputSize, 3])[:, :, :, 0]
             .flatten(1)
+            .to(torch.float32)
         )
         predictedObs = fwd_out["predictedObs"][lossMask]
         visionReconstructionLoss = torch.nn.functional.binary_cross_entropy(

--- a/models/agent_models.py
+++ b/models/agent_models.py
@@ -56,7 +56,7 @@ class MemoryMazeModule(SimpleMazeModule):
 
     @override(TorchRLModule)
     def get_initial_state(self):
-        return {"h": torch.zeros((self.linearHiddenSize,), dtype=torch.float32)}
+        return {"hiddenObs": torch.zeros((self.linearHiddenSize,), dtype=torch.float32)}
 
     def _processConvolution(self, vision) -> torch.Tensor:
         visionShape = vision.shape
@@ -68,7 +68,7 @@ class MemoryMazeModule(SimpleMazeModule):
         return visionFeatures
 
     def _processPreHeads(self, batch):
-        initialHidden = batch[Columns.STATE_IN]["h"].unsqueeze(0)
+        initialHidden = batch[Columns.STATE_IN]["hiddenObs"].unsqueeze(0)
         vision = batch[Columns.OBS]
         visionFeatures = self._processConvolution(vision)
         return self.trajectoryMemory(visionFeatures, initialHidden)
@@ -79,7 +79,7 @@ class MemoryMazeModule(SimpleMazeModule):
         policy = self.policy_branch(allHiddenStates)
         return {
             Columns.ACTION_DIST_INPUTS: policy,
-            Columns.STATE_OUT: {"h": finalHiddenState.squeeze(0)},
+            Columns.STATE_OUT: {"hiddenObs": finalHiddenState.squeeze(0)},
             Columns.EMBEDDINGS: allHiddenStates,
         }
 

--- a/models/agent_models.py
+++ b/models/agent_models.py
@@ -58,7 +58,7 @@ class MemoryMazeModule(SimpleMazeModule):
     def get_initial_state(self):
         return {"h": torch.zeros((self.linearHiddenSize,), dtype=torch.float32)}
 
-    def _processConvolution(self, vision):
+    def _processConvolution(self, vision) -> torch.Tensor:
         visionShape = vision.shape
         vision = vision.reshape(-1, *visionShape[2:])
         vision = vision.permute(0, 3, 1, 2).to(torch.float32)

--- a/models/latent_path_module.py
+++ b/models/latent_path_module.py
@@ -7,7 +7,6 @@ from ray.rllib.core.rl_module.apis import ValueFunctionAPI
 from ray.rllib.utils.annotations import override
 
 from .agent_models import MemoryMazeModule
-from .simple_conv import SimpleConv
 from .multi_head_lstm import MultiHeadLSTM
 
 NUM_MODULES = 2
@@ -31,21 +30,12 @@ class LatentPathModule(MemoryMazeModule):
         self.gridSize = 512
         self.numPlaceCells = 32
         self.mazeSize = self.model_config.get("mazeSize", 31)
-        self.memoryEncoder = nn.Sequential(
+        self.policyFeatureEncoder = nn.Sequential(
             nn.Linear(
-                self.linearHiddenSize + self.gridSize * NUM_MODULES,
+                self.gridSize * NUM_MODULES,
                 self.linearHiddenSize,
             ),
             nn.ReLU(),
-        )
-
-        self.gridConvModule = SimpleConv(self.hiddenSize)
-        self.preGridHead = nn.Sequential(
-            nn.Flatten(),
-            nn.Linear(
-                self.primaryConvModuleOutSize**2 * self.hiddenSize * 2,
-                self.linearHiddenSize,
-            ),
         )
 
         self.moduleProjector = ModuleProjector(
@@ -87,12 +77,6 @@ class LatentPathModule(MemoryMazeModule):
         ):
             nn.init.uniform_(w, -stdv, stdv)
 
-    def _processConvolutionForGrid(self, vision: torch.Tensor):
-        vision = vision.permute(0, 3, 1, 2).to(torch.float32)
-        visionFeatures = self.gridConvModule(vision)
-        visionFeatures = self.preGridHead(visionFeatures)
-        return visionFeatures
-
     def get_place_activation(self, coordinates: torch.Tensor):
         with torch.no_grad():
             originalShape = coordinates.shape[:-2]
@@ -104,23 +88,16 @@ class LatentPathModule(MemoryMazeModule):
                 -dist2 / (2 * self.fieldSize**2), dim=-1
             ).reshape([*originalShape, NUM_MODULES, self.numPlaceCells])
 
-    def _pathIntegrate(self, vision: torch.Tensor, previousVision: torch.Tensor):
-        batchSize = vision.shape[0]
-        sequenceLength = vision.shape[1]
-        previousVision = previousVision[:, 0, :]
-        latents = self._processConvolutionForGrid(
-            torch.concat([vision.flatten(0, 1), previousVision])
+    def _pathIntegrate(
+        self,
+        latents: torch.Tensor,
+        initialLatents: torch.Tensor,
+    ):
+        currentProjections = self.moduleProjector.forward(latents).reshape(
+            [*latents.shape[:2], NUM_MODULES, GRID_MODULE_DIM]
         )
-        modularProjections = self.moduleProjector.forward(latents)
-        currentProjections = (
-            modularProjections[:-batchSize]
-            .contiguous()
-            .reshape([batchSize, sequenceLength, NUM_MODULES, GRID_MODULE_DIM])
-        )
-        pastProjections = (
-            modularProjections[-batchSize:]
-            .contiguous()
-            .reshape([batchSize, NUM_MODULES, GRID_MODULE_DIM])
+        pastProjections = self.moduleProjector.forward(initialLatents).reshape(
+            [initialLatents.shape[0], NUM_MODULES, GRID_MODULE_DIM]
         )
         pastPlaceCellActivations = self.get_place_activation(pastProjections)
         encodedPlace = torch.einsum(
@@ -164,16 +141,6 @@ class LatentPathModule(MemoryMazeModule):
             ),
         }
 
-    def _getObsFromBatch(self, batch):
-        obs = batch["obs"]
-        visionSize = self.inputSize**2 * 3
-        vision = obs[:, :, :visionSize]
-        previousVision = obs[:, :, visionSize:]
-        visionShape = [*vision.shape[:2], self.inputSize, self.inputSize, 3]
-        vision = torch.reshape(vision, visionShape)
-        previousVision = torch.reshape(previousVision, visionShape)
-        return vision, previousVision
-
     # def _forward_exploration(self, batch, **kwargs):
     #     hiddenStates, _, finalGrid = self._processPreHeads(batch, True)
     #     policy = self.policy_branch(hiddenStates)
@@ -187,46 +154,48 @@ class LatentPathModule(MemoryMazeModule):
     #         Columns.EMBEDDINGS: hiddenStates,
     #     }
 
-    def _getPolicyInput(self, features, gridCode, initialHidden):
+    def _processPreHeads(self, batch):
+        vision = batch["obs"]
+        initialLatent = batch[Columns.STATE_IN]["hiddenObs"]
+        convLatents = self._processConvolution(vision)
+        latents, finalLatents = self.trajectoryMemory(
+            convLatents.reshape([*vision.shape[:2], self.linearHiddenSize]),
+            initialLatent.unsqueeze(0),
+        )
+        gridCode, predictedPlaces, actualPlaces, finalGrid = self._pathIntegrate(
+            latents, initialLatent
+        )
         with torch.no_grad():
             gridWithoutGrad = torch.Tensor(gridCode)
-        encodedMemory = self.memoryEncoder(
-            torch.concat([features, gridWithoutGrad], dim=2)
-        )
-        encodedMemory = self.trajectoryMemory(encodedMemory, initialHidden)
-        return encodedMemory[0]
-
-    def _processPreHeads(self, batch):
-        vision, previousVision = self._getObsFromBatch(batch)
-        visionFeatures = self._processConvolution(vision)
-        gridCode, predictedPlaces, actualPlaces, finalGrid = self._pathIntegrate(
-            vision, previousVision
-        )
-        initialHidden = batch[Columns.STATE_IN]["hiddenObs"].unsqueeze(0)
-        hiddenStates = self._getPolicyInput(visionFeatures, gridCode, initialHidden)
-        predictedObs = self.obsPredictor.forward(gridCode)
+        predictedObs = self.obsPredictor.forward(gridWithoutGrad)
         return (
-            hiddenStates,
+            self.policyFeatureEncoder(gridWithoutGrad),
             predictedPlaces,
             actualPlaces,
             finalGrid,
+            finalLatents,
             predictedObs,
         )
 
     @override(TorchRLModule)
     def _forward(self, batch, **kwargs):
-        hiddenStates, predictedPlaces, actualPlaces, finalGrid, predictedObs = (
-            self._processPreHeads(batch)
-        )
-        policy = self.policy_branch(hiddenStates)
+        (
+            policyFeature,
+            predictedPlaces,
+            actualPlaces,
+            finalGrid,
+            finalLatents,
+            predictedObs,
+        ) = self._processPreHeads(batch)
+        policy = self.policy_branch(policyFeature)
         return {
             Columns.ACTION_DIST_INPUTS: policy,
             Columns.STATE_OUT: {
-                "hiddenObs": hiddenStates[:, -1],
+                "hiddenObs": finalLatents.squeeze(0),
                 "candidateGrid": finalGrid[1].squeeze(0),
                 "hiddenGrid": finalGrid[0].squeeze(0),
             },
-            Columns.EMBEDDINGS: hiddenStates,
+            Columns.EMBEDDINGS: policyFeature,
             "placeLogit": predictedPlaces,
             "placeTarget": actualPlaces,
             "predictedObs": predictedObs,
@@ -235,5 +204,5 @@ class LatentPathModule(MemoryMazeModule):
     @override(ValueFunctionAPI)
     def compute_values(self, batch, embeddings=None):
         if embeddings is None:
-            embeddings, _, _, _, _ = self._processPreHeads(batch)
+            embeddings, _, _, _, _, _ = self._processPreHeads(batch)
         return self.value_branch(embeddings).squeeze(-1)

--- a/models/latent_path_module.py
+++ b/models/latent_path_module.py
@@ -84,12 +84,16 @@ class LatentPathModule(MemoryMazeModule):
         return visionFeatures
 
     def get_place_activation(self, coordinates: torch.Tensor):
-        originalShape = coordinates.shape[:-2]
-        diff = coordinates.flatten(0, -3).unsqueeze(2) - self.placeCells.unsqueeze(0)
-        dist2 = (diff**2).sum(dim=-1)
-        return torch.nn.functional.softmax(
-            torch.exp(-dist2 / (2 * self.fieldSize**2)), dim=-1
-        ).reshape([*originalShape, NUM_MODULES, self.numPlaceCells])
+        with torch.no_grad():
+            coordinates = coordinates - torch.floor(coordinates)
+            originalShape = coordinates.shape[:-2]
+            diff = coordinates.flatten(0, -3).unsqueeze(2) - self.placeCells.unsqueeze(
+                0
+            )
+            dist2 = (diff**2).sum(dim=-1)
+            return torch.nn.functional.softmax(
+                torch.exp(-dist2 / (2 * self.fieldSize**2)), dim=-1
+            ).reshape([*originalShape, NUM_MODULES, self.numPlaceCells])
 
     def _pathIntegrate(self, vision: torch.Tensor, previousVision: torch.Tensor):
         batchSize = vision.shape[0]
@@ -98,7 +102,7 @@ class LatentPathModule(MemoryMazeModule):
         latents = self._processConvolutionForGrid(
             torch.concat([vision.flatten(0, 1), previousVision])
         )
-        modularProjections = self.moduleProjector.forward(latents) % 1
+        modularProjections = self.moduleProjector.forward(latents)
         currentProjections = (
             modularProjections[:-batchSize]
             .contiguous()
@@ -108,7 +112,7 @@ class LatentPathModule(MemoryMazeModule):
             modularProjections[-batchSize:]
             .contiguous()
             .reshape([batchSize, NUM_MODULES, GRID_MODULE_DIM])
-        ) % 1
+        )
         pastPlaceCellActivations = self.get_place_activation(pastProjections)
         encodedPlace = torch.einsum(
             "bmp,mpe->bme", pastPlaceCellActivations, self.placeEncoderWeight
@@ -184,7 +188,7 @@ class LatentPathModule(MemoryMazeModule):
         return encodedMemory[0]
 
     def _processPreHeads(self, batch):
-        vision, previousVision, action = self._getObsFromBatch(batch)
+        vision, previousVision, _ = self._getObsFromBatch(batch)
         visionFeatures = self._processConvolution(vision)
         gridCode, predictedPlaces, actualPlaces, finalGrid = self._pathIntegrate(
             vision, previousVision

--- a/models/latent_path_module.py
+++ b/models/latent_path_module.py
@@ -62,6 +62,11 @@ class LatentPathModule(MemoryMazeModule):
         self.placeEncoderBias = nn.Parameter(
             torch.Tensor(NUM_MODULES, self.numPlaceCells)
         )
+        self.actionPredictor = nn.Sequential(
+            nn.Linear(self.gridSize * NUM_MODULES, self.gridSize),
+            nn.ReLU(),
+            nn.Linear(self.gridSize, 5),
+        )
         stdv = 1.0 / math.sqrt(self.integratorSize)
         for w in (
             self.gridProjectorWeight,
@@ -128,7 +133,7 @@ class LatentPathModule(MemoryMazeModule):
             "btmg,mgp->btmp", gridCodes, self.placeDecoderWeight
         )
         return (
-            gridCodes,
+            gridCodes.flatten(2, 3),
             predictedPlaceLogit,
             self.get_place_activation(currentProjections),
             finalStates,
@@ -150,11 +155,11 @@ class LatentPathModule(MemoryMazeModule):
         obs = batch["obs"]
         visionSize = self.inputSize**2 * 3
         vision = obs[:, :, :visionSize]
-        previousVision = obs[:, :, visionSize:]
+        previousVision = obs[:, :, visionSize:-5]
         visionShape = [*vision.shape[:2], self.inputSize, self.inputSize, 3]
         vision = torch.reshape(vision, visionShape)
         previousVision = torch.reshape(previousVision, visionShape)
-        return vision, previousVision
+        return vision, previousVision, obs[:, :, -5:]
 
     # def _forward_exploration(self, batch, **kwargs):
     #     hiddenStates, _, finalGrid = self._processPreHeads(batch, True)
@@ -171,7 +176,7 @@ class LatentPathModule(MemoryMazeModule):
 
     def _getPolicyInput(self, features, gridCode, initialHidden):
         with torch.no_grad():
-            gridWithoutGrad = torch.Tensor(gridCode).flatten(2, 3)
+            gridWithoutGrad = torch.Tensor(gridCode)
         encodedMemory = self.memoryEncoder(
             torch.concat([features, gridWithoutGrad], dim=2)
         )
@@ -179,19 +184,26 @@ class LatentPathModule(MemoryMazeModule):
         return encodedMemory[0]
 
     def _processPreHeads(self, batch):
-        vision, previousVision = self._getObsFromBatch(batch)
+        vision, previousVision, action = self._getObsFromBatch(batch)
         visionFeatures = self._processConvolution(vision)
         gridCode, predictedPlaces, actualPlaces, finalGrid = self._pathIntegrate(
             vision, previousVision
         )
         initialHidden = batch[Columns.STATE_IN]["hiddenObs"].unsqueeze(0)
         hiddenStates = self._getPolicyInput(visionFeatures, gridCode, initialHidden)
-        return hiddenStates, predictedPlaces, actualPlaces, finalGrid
+        predictedAction = self.actionPredictor.forward(gridCode)
+        return (
+            hiddenStates,
+            predictedPlaces,
+            actualPlaces,
+            finalGrid,
+            predictedAction,
+        )
 
     @override(TorchRLModule)
     def _forward(self, batch, **kwargs):
-        hiddenStates, predictedPlaces, actualPlaces, finalGrid = self._processPreHeads(
-            batch
+        hiddenStates, predictedPlaces, actualPlaces, finalGrid, predictedAction = (
+            self._processPreHeads(batch)
         )
         policy = self.policy_branch(hiddenStates)
         return {
@@ -204,10 +216,11 @@ class LatentPathModule(MemoryMazeModule):
             Columns.EMBEDDINGS: hiddenStates,
             "placeLogit": predictedPlaces,
             "placeTarget": actualPlaces,
+            "predictedAction": predictedAction,
         }
 
     @override(ValueFunctionAPI)
     def compute_values(self, batch, embeddings=None):
         if embeddings is None:
-            embeddings, _, _, _ = self._processPreHeads(batch)
+            embeddings, _, _, _, _ = self._processPreHeads(batch)
         return self.value_branch(embeddings).squeeze(-1)

--- a/models/latent_path_module.py
+++ b/models/latent_path_module.py
@@ -167,7 +167,7 @@ class LatentPathModule(MemoryMazeModule):
         )
         with torch.no_grad():
             gridWithoutGrad = torch.Tensor(gridCode)
-        predictedObs = self.obsPredictor.forward(gridWithoutGrad)
+        predictedObs = self.obsPredictor.forward(gridCode)
         return (
             self.policyFeatureEncoder(gridWithoutGrad),
             predictedPlaces,

--- a/models/latent_path_module.py
+++ b/models/latent_path_module.py
@@ -30,9 +30,15 @@ class LatentPathModule(MemoryMazeModule):
         self.gridSize = 512
         self.numPlaceCells = 32
         self.mazeSize = self.model_config.get("mazeSize", 31)
-        self.policyFeatureEncoder = nn.Sequential(
+        self.gridCompressor = nn.Sequential(
+            nn.Linear(self.gridSize * NUM_MODULES, self.gridSize),
+            nn.ReLU(),
+            nn.Linear(self.gridSize, self.linearHiddenSize),
+            nn.ReLU(),
+        )
+        self.memoryEncoder = nn.Sequential(
             nn.Linear(
-                self.gridSize * NUM_MODULES,
+                self.linearHiddenSize * 2,
                 self.linearHiddenSize,
             ),
             nn.ReLU(),
@@ -59,13 +65,7 @@ class LatentPathModule(MemoryMazeModule):
             torch.Tensor(NUM_MODULES, self.numPlaceCells, 2 * self.integratorSize)
         )
         self.placeEncoderBias = nn.Parameter(
-            torch.Tensor(NUM_MODULES, self.numPlaceCells)
-        )
-        self.obsPredictor = nn.Sequential(
-            nn.Linear(self.gridSize * NUM_MODULES, self.gridSize),
-            nn.ReLU(),
-            nn.Linear(self.gridSize, self.inputSize**2),
-            nn.Sigmoid(),
+            torch.Tensor(NUM_MODULES, 2 * self.integratorSize)
         )
         stdv = 1.0 / math.sqrt(self.integratorSize)
         for w in (
@@ -102,7 +102,7 @@ class LatentPathModule(MemoryMazeModule):
         pastPlaceCellActivations = self.get_place_activation(pastProjections)
         encodedPlace = torch.einsum(
             "bmp,mpe->bme", pastPlaceCellActivations, self.placeEncoderWeight
-        )
+        ) + self.placeEncoderBias.unsqueeze(0)
         initialHidden = encodedPlace[:, :, : self.integratorSize].contiguous()
         initialCandidate = encodedPlace[:, :, self.integratorSize :].contiguous()
         movements = currentProjections - torch.concat(
@@ -123,7 +123,7 @@ class LatentPathModule(MemoryMazeModule):
             "btmg,mgp->btmp", gridCodes, self.placeDecoderWeight
         )
         return (
-            gridCodes.flatten(2, 3),
+            gridCodes.flatten(2),
             predictedPlaceLogit,
             self.get_place_activation(currentProjections),
             finalStates,
@@ -154,27 +154,30 @@ class LatentPathModule(MemoryMazeModule):
     #         Columns.EMBEDDINGS: hiddenStates,
     #     }
 
-    def _processPreHeads(self, batch):
-        vision = batch["obs"]
-        initialLatent = batch[Columns.STATE_IN]["hiddenObs"]
-        convLatents = self._processConvolution(vision)
-        latents, finalLatents = self.trajectoryMemory(
-            convLatents.reshape([*vision.shape[:2], self.linearHiddenSize]),
-            initialLatent.unsqueeze(0),
-        )
-        gridCode, predictedPlaces, actualPlaces, finalGrid = self._pathIntegrate(
-            latents, initialLatent
-        )
+    def _getPolicyInput(self, features, gridCode):
         with torch.no_grad():
             gridWithoutGrad = torch.Tensor(gridCode)
-        predictedObs = self.obsPredictor.forward(gridCode)
+        compressedGrid = self.gridCompressor.forward(gridWithoutGrad)
+        encodedMemory = self.memoryEncoder(
+            torch.concat([features, compressedGrid], dim=2)
+        )
+        return encodedMemory
+
+    def _processPreHeads(self, batch):
+        initialLatent = batch[Columns.STATE_IN]["hiddenObs"]
+        latents, finalLatents = super()._processPreHeads(batch)
+        with torch.no_grad():
+            latentsWithoutGrad = torch.Tensor(latents)
+        gridCode, predictedPlaces, actualPlaces, finalGrid = self._pathIntegrate(
+            latentsWithoutGrad, initialLatent
+        )
+
         return (
-            self.policyFeatureEncoder(gridWithoutGrad),
+            self._getPolicyInput(latents, gridCode),
             predictedPlaces,
             actualPlaces,
             finalGrid,
             finalLatents,
-            predictedObs,
         )
 
     @override(TorchRLModule)
@@ -185,7 +188,6 @@ class LatentPathModule(MemoryMazeModule):
             actualPlaces,
             finalGrid,
             finalLatents,
-            predictedObs,
         ) = self._processPreHeads(batch)
         policy = self.policy_branch(policyFeature)
         return {
@@ -198,11 +200,10 @@ class LatentPathModule(MemoryMazeModule):
             Columns.EMBEDDINGS: policyFeature,
             "placeLogit": predictedPlaces,
             "placeTarget": actualPlaces,
-            "predictedObs": predictedObs,
         }
 
     @override(ValueFunctionAPI)
     def compute_values(self, batch, embeddings=None):
         if embeddings is None:
-            embeddings, _, _, _, _, _ = self._processPreHeads(batch)
+            embeddings, _, _, _, _ = self._processPreHeads(batch)
         return self.value_branch(embeddings).squeeze(-1)

--- a/models/latent_path_module.py
+++ b/models/latent_path_module.py
@@ -62,10 +62,11 @@ class LatentPathModule(MemoryMazeModule):
         self.placeEncoderBias = nn.Parameter(
             torch.Tensor(NUM_MODULES, self.numPlaceCells)
         )
-        self.actionPredictor = nn.Sequential(
+        self.obsPredictor = nn.Sequential(
             nn.Linear(self.gridSize * NUM_MODULES, self.gridSize),
             nn.ReLU(),
-            nn.Linear(self.gridSize, 5),
+            nn.Linear(self.gridSize, self.inputSize**2),
+            nn.Sigmoid(),
         )
         stdv = 1.0 / math.sqrt(self.integratorSize)
         for w in (
@@ -159,11 +160,11 @@ class LatentPathModule(MemoryMazeModule):
         obs = batch["obs"]
         visionSize = self.inputSize**2 * 3
         vision = obs[:, :, :visionSize]
-        previousVision = obs[:, :, visionSize:-5]
+        previousVision = obs[:, :, visionSize:]
         visionShape = [*vision.shape[:2], self.inputSize, self.inputSize, 3]
         vision = torch.reshape(vision, visionShape)
         previousVision = torch.reshape(previousVision, visionShape)
-        return vision, previousVision, obs[:, :, -5:]
+        return vision, previousVision
 
     # def _forward_exploration(self, batch, **kwargs):
     #     hiddenStates, _, finalGrid = self._processPreHeads(batch, True)
@@ -188,25 +189,25 @@ class LatentPathModule(MemoryMazeModule):
         return encodedMemory[0]
 
     def _processPreHeads(self, batch):
-        vision, previousVision, _ = self._getObsFromBatch(batch)
+        vision, previousVision = self._getObsFromBatch(batch)
         visionFeatures = self._processConvolution(vision)
         gridCode, predictedPlaces, actualPlaces, finalGrid = self._pathIntegrate(
             vision, previousVision
         )
         initialHidden = batch[Columns.STATE_IN]["hiddenObs"].unsqueeze(0)
         hiddenStates = self._getPolicyInput(visionFeatures, gridCode, initialHidden)
-        predictedAction = self.actionPredictor.forward(gridCode)
+        predictedObs = self.obsPredictor.forward(gridCode)
         return (
             hiddenStates,
             predictedPlaces,
             actualPlaces,
             finalGrid,
-            predictedAction,
+            predictedObs,
         )
 
     @override(TorchRLModule)
     def _forward(self, batch, **kwargs):
-        hiddenStates, predictedPlaces, actualPlaces, finalGrid, predictedAction = (
+        hiddenStates, predictedPlaces, actualPlaces, finalGrid, predictedObs = (
             self._processPreHeads(batch)
         )
         policy = self.policy_branch(hiddenStates)
@@ -220,7 +221,7 @@ class LatentPathModule(MemoryMazeModule):
             Columns.EMBEDDINGS: hiddenStates,
             "placeLogit": predictedPlaces,
             "placeTarget": actualPlaces,
-            "predictedAction": predictedAction,
+            "predictedObs": predictedObs,
         }
 
     @override(ValueFunctionAPI)

--- a/models/latent_path_module.py
+++ b/models/latent_path_module.py
@@ -14,6 +14,16 @@ NUM_MODULES = 2
 GRID_MODULE_DIM = 2
 
 
+class ModuleProjector(nn.Module):
+    def __init__(self, inputSize: int, outputSize: int):
+        super().__init__()
+        self.weight = nn.Parameter(torch.randn(outputSize, inputSize))
+
+    def forward(self, z):
+        normalizedWeight = torch.softmax(self.weight, dim=1)
+        return torch.sigmoid(z) @ normalizedWeight.T
+
+
 class LatentPathModule(MemoryMazeModule):
     def setup(self):
         MemoryMazeModule.setup(self)
@@ -36,11 +46,10 @@ class LatentPathModule(MemoryMazeModule):
                 self.primaryConvModuleOutSize**2 * self.hiddenSize * 2,
                 self.linearHiddenSize,
             ),
-            nn.ReLU(),
         )
 
-        self.moduleProjector = nn.Linear(
-            self.linearHiddenSize, GRID_MODULE_DIM * NUM_MODULES, bias=False
+        self.moduleProjector = ModuleProjector(
+            self.linearHiddenSize, GRID_MODULE_DIM * NUM_MODULES
         )
         self.pathIntegrator = MultiHeadLSTM(
             GRID_MODULE_DIM, self.integratorSize, NUM_MODULES
@@ -86,14 +95,13 @@ class LatentPathModule(MemoryMazeModule):
 
     def get_place_activation(self, coordinates: torch.Tensor):
         with torch.no_grad():
-            coordinates = coordinates - torch.floor(coordinates)
             originalShape = coordinates.shape[:-2]
             diff = coordinates.flatten(0, -3).unsqueeze(2) - self.placeCells.unsqueeze(
                 0
             )
             dist2 = (diff**2).sum(dim=-1)
             return torch.nn.functional.softmax(
-                torch.exp(-dist2 / (2 * self.fieldSize**2)), dim=-1
+                -dist2 / (2 * self.fieldSize**2), dim=-1
             ).reshape([*originalShape, NUM_MODULES, self.numPlaceCells])
 
     def _pathIntegrate(self, vision: torch.Tensor, previousVision: torch.Tensor):

--- a/train.py
+++ b/train.py
@@ -172,13 +172,13 @@ if __name__ == "__main__":
                             result["learners"]["default_policy"]["orthonormal_loss"], 2
                         )
                         print("Orthonormal Loss:", orthoLoss)
-                        actionLoss = np.round(
+                        visionLoss = np.round(
                             result["learners"]["default_policy"][
-                                "action_awareness_loss"
+                                "vision_reconstruction_loss"
                             ],
                             2,
                         )
-                        print("Action Loss:", actionLoss)
+                        print("Vision Loss:", visionLoss)
                     # placeBias = np.round(
                     #     result["learners"]["default_policy"]["place_bias"], 2
                     # )

--- a/train.py
+++ b/train.py
@@ -171,13 +171,6 @@ if __name__ == "__main__":
                             result["learners"]["default_policy"]["orthonormal_loss"], 2
                         )
                         print("Orthonormal Loss:", orthoLoss)
-                        visionLoss = np.round(
-                            result["learners"]["default_policy"][
-                                "vision_reconstruction_loss"
-                            ],
-                            2,
-                        )
-                        print("Vision Loss:", visionLoss)
                     # placeBias = np.round(
                     #     result["learners"]["default_policy"]["place_bias"], 2
                     # )

--- a/train.py
+++ b/train.py
@@ -172,6 +172,13 @@ if __name__ == "__main__":
                             result["learners"]["default_policy"]["orthonormal_loss"], 2
                         )
                         print("Orthonormal Loss:", orthoLoss)
+                        actionLoss = np.round(
+                            result["learners"]["default_policy"][
+                                "action_awareness_loss"
+                            ],
+                            2,
+                        )
+                        print("Action Loss:", actionLoss)
                     # placeBias = np.round(
                     #     result["learners"]["default_policy"]["place_bias"], 2
                     # )

--- a/train.py
+++ b/train.py
@@ -14,7 +14,6 @@ from environments import (
     MazeEnv,
     FoggedMazeEnv,
     PlaceMazeEnv,
-    MemoryMazeEnv,
 )
 from learners.ppo_grid_learner import PPOTorchLearnerWithSelfPredLoss
 import models  # noqa: F401
@@ -85,7 +84,7 @@ if __name__ == "__main__":
         module = models.SimpleMazeModule
 
     if args.latentPath:
-        env = MemoryMazeEnv
+        env = FoggedMazeEnv
     elif args.grid or args.gps:
         env = PlaceMazeEnv
     elif args.fogged:


### PR DESCRIPTION
### Stabilized path integration backpropagation
Cannot explicitly use modulo arithmetic. I find that it leads to an explosion in training loss when I do this. Instead, I bind the values of projected modules to be within 0 and 1.

### Revert to path integration input relying completely on policy latent
It doesn't make sense for grid code to not be dependent on the policy (and value) latent. What I am after is for the grid code to understand subtask completion, but it can't do that if it doesn't have an understanding of policy.

### Minimize grid code's effect on policy function to stabilize policy learning
If the grid code size is too big, it will dilute the latents learned by policy and value functions. To prevent this, I concatenate the grid code with the latent only after compressing it.

### Remove custom environment
The custom environment's only purpose was to provide the previous environment observation at each step, but that is not necessary since we can just use previous hidden states provided by RLModule.

Also fixed a few correctness mistakes.