### PR TITLE
Test self-localization extrapolation without grid code

### DIFF
--- a/environments.py
+++ b/environments.py
@@ -230,8 +230,8 @@ class PlaceMazeEnv(FoggedMazeEnv):
         return np.concatenate(
             [
                 vision.flatten(),
-                self._lastLocation / (self._mazeSize - 1),
-                self._agentLocation / (self._mazeSize - 1),
+                self._lastLocation / self._mazeSize,
+                self._agentLocation / self._mazeSize,
                 actionOneHot,
             ],
             dtype=np.float32,

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,2 +1,3 @@
 from .agent_models import *  # noqa: F403
 from .latent_path_module import LatentPathModule  # noqa: F401
+from .place_cell_control_agent import PlaceCellControlModule  # noqa: F401

--- a/models/agent_models.py
+++ b/models/agent_models.py
@@ -114,13 +114,10 @@ class MemoryMazeWithInitialPlaceModule(MemoryMazeModule):
         prevPlaces = self.placeEncoder(
             calculatePlace(self.placeCells, lastAgentLocation)[:, 0, :]
         )
-        if self.training:
-            initialHidden = prevPlaces
-        else:
-            initialPlaceMask = torch.sum(initialHidden, 1) == 0
-            initialHidden = torch.where(
-                initialPlaceMask[:, None], prevPlaces, initialHidden
-            )
+        initialPlaceMask = torch.sum(initialHidden, 1) == 0
+        initialHidden = torch.where(
+            initialPlaceMask[:, None], prevPlaces, initialHidden
+        )
         visionFeatures = self._processConvolution(vision)
         return self.trajectoryMemory(visionFeatures, initialHidden.unsqueeze(0))
 

--- a/models/agent_models.py
+++ b/models/agent_models.py
@@ -90,38 +90,6 @@ class MemoryMazeModule(SimpleMazeModule):
         return self.value_branch(self._processPreHeads(batch)[0]).squeeze(-1)
 
 
-class MemoryMazeWithInitialPlaceModule(MemoryMazeModule):
-    def setup(self):
-        MemoryMazeModule.setup(self)
-        self.numPlaceCells = self.model_config.get("numPlaceCells", 32)
-        self.placeEncoder = nn.Linear(self.numPlaceCells, self.linearHiddenSize)
-        self.placeCells = nn.Parameter(torch.rand([self.numPlaceCells, 2]), False)
-
-    def _getObsFromBatch(self, batch):
-        obs = batch["obs"]
-        visionSize = self.inputSize**2 * 2
-        vision = obs[:, :, :visionSize]
-        vision = torch.reshape(
-            vision, [*vision.shape[:2], self.inputSize, self.inputSize, 2]
-        )
-        lastAgentLocation = obs[:, :, visionSize : visionSize + 2]
-        lastAgentLocation = lastAgentLocation.reshape(*lastAgentLocation.shape[:2], 2)
-        return vision, lastAgentLocation
-
-    def _processPreHeads(self, batch):
-        initialHidden: torch.Tensor = batch[Columns.STATE_IN]["hiddenObs"]
-        vision, lastAgentLocation = self._getObsFromBatch(batch)
-        prevPlaces = self.placeEncoder(
-            calculatePlace(self.placeCells, lastAgentLocation)[:, 0, :]
-        )
-        initialPlaceMask = torch.sum(initialHidden, 1) == 0
-        initialHidden = torch.where(
-            initialPlaceMask[:, None], prevPlaces, initialHidden
-        )
-        visionFeatures = self._processConvolution(vision)
-        return self.trajectoryMemory(visionFeatures, initialHidden.unsqueeze(0))
-
-
 class PlaceMazeModule(MemoryMazeModule):
     def setup(self):
         MemoryMazeModule.setup(self)

--- a/models/agent_models.py
+++ b/models/agent_models.py
@@ -7,6 +7,7 @@ from ray.rllib.core.rl_module.apis import ValueFunctionAPI
 from ray.rllib.utils.annotations import override
 
 from .simple_conv import SimpleConv
+from .utils import calculatePlace
 
 
 class SimpleMazeModule(TorchRLModule, ValueFunctionAPI):
@@ -89,6 +90,41 @@ class MemoryMazeModule(SimpleMazeModule):
         return self.value_branch(self._processPreHeads(batch)[0]).squeeze(-1)
 
 
+class MemoryMazeWithInitialPlaceModule(MemoryMazeModule):
+    def setup(self):
+        MemoryMazeModule.setup(self)
+        self.numPlaceCells = self.model_config.get("numPlaceCells", 32)
+        self.placeEncoder = nn.Linear(self.numPlaceCells, self.linearHiddenSize)
+        self.placeCells = nn.Parameter(torch.rand([self.numPlaceCells, 2]), False)
+
+    def _getObsFromBatch(self, batch):
+        obs = batch["obs"]
+        visionSize = self.inputSize**2 * 2
+        vision = obs[:, :, :visionSize]
+        vision = torch.reshape(
+            vision, [*vision.shape[:2], self.inputSize, self.inputSize, 2]
+        )
+        lastAgentLocation = obs[:, :, visionSize : visionSize + 2]
+        lastAgentLocation = lastAgentLocation.reshape(*lastAgentLocation.shape[:2], 2)
+        return vision, lastAgentLocation
+
+    def _processPreHeads(self, batch):
+        initialHidden: torch.Tensor = batch[Columns.STATE_IN]["hiddenObs"]
+        vision, lastAgentLocation = self._getObsFromBatch(batch)
+        prevPlaces = self.placeEncoder(
+            calculatePlace(self.placeCells, lastAgentLocation)[:, 0, :]
+        )
+        if self.training:
+            initialHidden = prevPlaces
+        else:
+            initialPlaceMask = torch.sum(initialHidden, 1) == 0
+            initialHidden = torch.where(
+                initialPlaceMask[:, None], prevPlaces, initialHidden
+            )
+        visionFeatures = self._processConvolution(vision)
+        return self.trajectoryMemory(visionFeatures, initialHidden.unsqueeze(0))
+
+
 class PlaceMazeModule(MemoryMazeModule):
     def setup(self):
         MemoryMazeModule.setup(self)
@@ -105,7 +141,6 @@ class PlaceMazeModule(MemoryMazeModule):
             nn.Linear(self.linearHiddenSize + self.gridSize, self.linearHiddenSize),
             nn.ReLU(),
         )
-        self.initialStates = nn.Embedding(2, self.integratorSize)
         self.placeCells = nn.Parameter(torch.rand([self.numPlaceCells, 2]), False)
         self.fieldSize = 0.3 / math.sqrt(self.numPlaceCells)
         self.placeEncoder = nn.Linear(self.numPlaceCells, 2 * self.integratorSize)
@@ -117,20 +152,6 @@ class PlaceMazeModule(MemoryMazeModule):
             ),
             nn.ReLU(),
         )
-
-    def _calculatePlace(self, agentLocation: torch.Tensor):
-        with torch.no_grad():
-            agentLocationShape = agentLocation.shape
-            agentLocation = agentLocation.flatten(0, -2)
-            diff = agentLocation.unsqueeze(1) - self.placeCells.unsqueeze(0)
-            dists_squared = torch.sum(torch.abs(diff) ** 2, dim=-1)
-            unnormalized_activations = -dists_squared / (2 * self.fieldSize**2)
-            normalized_activations = torch.nn.functional.softmax(
-                unnormalized_activations, dim=1
-            )
-            return normalized_activations.reshape(
-                [*agentLocationShape[:2], self.numPlaceCells]
-            )
 
     """
     Following code is used to figure out how dramatically place code can change
@@ -184,20 +205,22 @@ class PlaceMazeModule(MemoryMazeModule):
         action = obs[:, :, -5:]
         return vision, lastAgentLocation, agentLocation, action
 
-    def _processPreHeads(self, batch, eval: bool = False):
+    def _processPreHeads(self, batch):
         vision, lastAgentLocation, _, action = self._getObsFromBatch(batch)
         visionFeatures = self._processConvolution(vision)
-        prevPlaces = self.placeEncoder(self._calculatePlace(lastAgentLocation)[:, 0, :])
+        prevPlaces = self.placeEncoder(
+            calculatePlace(self.placeCells, lastAgentLocation)[:, 0, :]
+        )
         hiddenGrid = prevPlaces[:, : self.integratorSize].contiguous()
         candidateGrid = prevPlaces[:, self.integratorSize :].contiguous()
-        if eval:
+        if not self.training:
             hiddenPlace = hiddenGrid
             candidatePlace = candidateGrid
             hiddenGrid = batch[Columns.STATE_IN]["hiddenGrid"]
             candidateGrid = batch[Columns.STATE_IN]["candidateGrid"]
             initialPlaceMask = torch.sum(hiddenGrid, 1) == 0
             randomPlaceMask = (
-                torch.rand(initialPlaceMask.shape, dtype=torch.float32) < 0.05
+                torch.rand(initialPlaceMask.shape, dtype=torch.float32) < 0
             )
             placeMask = torch.where(randomPlaceMask, randomPlaceMask, initialPlaceMask)[
                 :, None
@@ -223,7 +246,7 @@ class PlaceMazeModule(MemoryMazeModule):
         )
 
     def _forward_exploration(self, batch, **kwargs):
-        hiddenStates, _, finalGrid = self._processPreHeads(batch, True)
+        hiddenStates, _, finalGrid = self._processPreHeads(batch)
         policy = self.policy_branch(hiddenStates)
         return {
             Columns.ACTION_DIST_INPUTS: policy,
@@ -249,7 +272,7 @@ class PlaceMazeModule(MemoryMazeModule):
             },
             Columns.EMBEDDINGS: hiddenStates,
             "placeLogit": projectedPlace,
-            "placeTarget": self._calculatePlace(agentLocation),
+            "placeTarget": calculatePlace(self.placeCells, agentLocation),
             "placeCells": self.placeCells.unsqueeze(0)
             .unsqueeze(0)
             .expand([*projectedPlace.shape[:2], self.numPlaceCells, 2]),

--- a/models/place_cell_control_agent.py
+++ b/models/place_cell_control_agent.py
@@ -1,0 +1,38 @@
+import torch
+import torch.nn as nn
+from ray.rllib.core.columns import Columns
+
+from .agent_models import MemoryMazeModule
+from .utils import calculatePlace
+
+
+class PlaceCellControlModule(MemoryMazeModule):
+    def setup(self):
+        MemoryMazeModule.setup(self)
+        self.numPlaceCells = self.model_config.get("numPlaceCells", 32)
+        self.placeEncoder = nn.Linear(self.numPlaceCells, self.linearHiddenSize)
+        self.placeCells = nn.Parameter(torch.rand([self.numPlaceCells, 2]), False)
+
+    def _getObsFromBatch(self, batch):
+        obs = batch["obs"]
+        visionSize = self.inputSize**2 * 2
+        vision = obs[:, :, :visionSize]
+        vision = torch.reshape(
+            vision, [*vision.shape[:2], self.inputSize, self.inputSize, 2]
+        )
+        lastAgentLocation = obs[:, :, visionSize : visionSize + 2]
+        lastAgentLocation = lastAgentLocation.reshape(*lastAgentLocation.shape[:2], 2)
+        return vision, lastAgentLocation
+
+    def _processPreHeads(self, batch):
+        initialHidden: torch.Tensor = batch[Columns.STATE_IN]["hiddenObs"]
+        vision, lastAgentLocation = self._getObsFromBatch(batch)
+        prevPlaces = self.placeEncoder(
+            calculatePlace(self.placeCells, lastAgentLocation)[:, 0, :]
+        )
+        initialPlaceMask = torch.sum(initialHidden, 1) == 0
+        initialHidden = torch.where(
+            initialPlaceMask[:, None], prevPlaces, initialHidden
+        )
+        visionFeatures = self._processConvolution(vision)
+        return self.trajectoryMemory(visionFeatures, initialHidden.unsqueeze(0))

--- a/models/utils.py
+++ b/models/utils.py
@@ -1,0 +1,20 @@
+import torch
+import math
+
+
+def calculatePlace(
+    placeCells: torch.Tensor,
+    agentLocation: torch.Tensor,
+    numPlaceCells: int = 32,
+    fieldSize: float = 0.3 / math.sqrt(32),
+):
+    with torch.no_grad():
+        agentLocationShape = agentLocation.shape
+        agentLocation = agentLocation.flatten(0, -2)
+        diff = agentLocation.unsqueeze(1) - placeCells.unsqueeze(0)
+        dists_squared = torch.sum(torch.abs(diff) ** 2, dim=-1)
+        unnormalized_activations = -dists_squared / (2 * fieldSize)
+        normalized_activations = torch.nn.functional.softmax(
+            unnormalized_activations, dim=1
+        )
+        return normalized_activations.reshape([*agentLocationShape[:2], numPlaceCells])

--- a/train.py
+++ b/train.py
@@ -81,7 +81,7 @@ if __name__ == "__main__":
     elif args.gps:
         module = models.GPSModule
     elif args.memoryLen > 1 and args.fogged:
-        module = models.MemoryMazeModule
+        module = models.MemoryMazeWithInitialPlaceModule
     else:
         module = models.SimpleMazeModule
 
@@ -89,10 +89,8 @@ if __name__ == "__main__":
         env = FoggedMazeEnv
     elif args.selfLocalize:
         env = SelfLocalizeEnv
-    elif args.grid or args.gps:
+    elif args.grid or args.gps or args.fogged:
         env = PlaceMazeEnv
-    elif args.fogged:
-        env = FoggedMazeEnv
     else:
         env = MazeEnv
 

--- a/train.py
+++ b/train.py
@@ -81,7 +81,7 @@ if __name__ == "__main__":
     elif args.gps:
         module = models.GPSModule
     elif args.memoryLen > 1 and args.fogged:
-        module = models.MemoryMazeWithInitialPlaceModule
+        module = models.PlaceCellControlModule
     else:
         module = models.SimpleMazeModule
 


### PR DESCRIPTION
Give a pure memory agent the initial place cell activation so that when I compare it with an agent that path integrated, the only thing different would be learning path integration, and nothing else. It would eliminate the initial place code advantage.