### PR TITLE
Prevent observation distribution shift in expanded environment

### DIFF
--- a/environments.py
+++ b/environments.py
@@ -12,8 +12,9 @@ class MazeEnv(gym.Env):
         self._episode_len = 0
         self._mazeArray = config.get("maze", None)
         self._mazeSize = config.get("mazeSize", None)
+        self._actualMazeSize = self._mazeSize * 2
         self._randomMaze = not self._mazeArray
-        self._goalLocation = config.get("goal", None)
+        self._goalLocation = [self._mazeSize, self._mazeSize]
         self._fixedGoal = bool(self._goalLocation)
         self._startLocation = config.get("start", None)
         self._maxSteps = config["maxSteps"]
@@ -58,26 +59,18 @@ class MazeEnv(gym.Env):
     def reset(self, *, seed: Optional[int] = None, options: Optional[dict] = None):
         super().reset(seed=seed)
         if self._randomMaze:
-            self._mazeArray = generateMaze(self._mazeSize)
+            self._mazeArray = generateMaze(self._actualMazeSize)
 
         mazeSize = len(self._mazeArray)
-        if not self._fixedGoal:
-            goalLocation = self.np_random.integers(0, mazeSize, size=2, dtype=int)
-            while (
-                not self._mazeArray[goalLocation[0]][goalLocation[1]]
-                or goalLocation[0] == mazeSize // 2
-                and goalLocation[1] == mazeSize // 2
-            ):
-                goalLocation = self.np_random.integers(0, mazeSize, size=2, dtype=int)
-            self._goalLocation = goalLocation
 
         targetChannel = np.zeros([mazeSize, mazeSize, 1], dtype=np.int32)
         targetChannel[self._goalLocation[0], self._goalLocation[1], 0] = 1
         agentChannel = np.zeros([mazeSize, mazeSize, 1], dtype=np.int32)
         if not self._startLocation:
             allLocations = []
-            for i in range(self._mazeSize):
-                for j in range(self._mazeSize):
+            _range = range(self._mazeSize // 2, self._mazeSize // 2 + self._mazeSize)
+            for i in _range:
+                for j in _range:
                     allLocations.append((i, j))
             np.random.shuffle(allLocations)
             agentLocation = np.array(allLocations.pop())
@@ -98,10 +91,10 @@ class MazeEnv(gym.Env):
             self._agentLocation = np.array(self._startLocation, dtype=np.int32)
 
         self._mazeTracker = []
-        for i in range(self._mazeSize):
+        for i in range(self._actualMazeSize):
             currentRow = []
             self._mazeTracker.append(currentRow)
-            for j in range(self._mazeSize):
+            for j in range(self._actualMazeSize):
                 originalValue = self._mazeArray[i][j]
                 if not originalValue:
                     currentRow.append("X")
@@ -163,10 +156,11 @@ class MazeEnv(gym.Env):
 
     def render(self):
         renderOutput = [
-            [i for i in range(self._mazeSize)] for j in range(self._mazeSize)
+            [i for i in range(self._actualMazeSize)]
+            for j in range(self._actualMazeSize)
         ]
-        for i in range(self._mazeSize):
-            for j in range(self._mazeSize):
+        for i in range(self._actualMazeSize):
+            for j in range(self._actualMazeSize):
                 if not self._mazeTracker[i][j]:
                     renderOutput[i][j] = " "
                 else:
@@ -228,8 +222,8 @@ class PlaceMazeEnv(FoggedMazeEnv):
         return np.concatenate(
             [
                 vision.flatten(),
-                self._lastLocation / self._mazeSize,
-                self._agentLocation / self._mazeSize,
+                (self._lastLocation - self._mazeSize // 2) / self._mazeSize,
+                (self._lastLocation - self._mazeSize // 2) / self._mazeSize,
                 actionOneHot,
             ],
             dtype=np.float32,
@@ -243,10 +237,11 @@ class SelfLocalizeEnv(PlaceMazeEnv):
         self._lastLocation = self._agentLocation
         self._lastAction = np.random.randint(0, 4)
         self._visitCounts = [
-            [0 for j in range(self._mazeSize)] for i in range(self._mazeSize)
+            [0 for j in range(self._actualMazeSize)]
+            for i in range(self._actualMazeSize)
         ]
         self.observation_space = gym.spaces.Box(
-            0, self._mazeSize, (visualObsSize**2 * 2 + 4 + self.action_space.n + 1,)
+            0, 1, (visualObsSize**2 * 2 + 4 + self.action_space.n + 1,)
         )
         self.previousActions = None
 

--- a/environments.py
+++ b/environments.py
@@ -77,9 +77,7 @@ class MazeEnv(gym.Env):
             goalDiff = np.abs(agentLocation - self._goalLocation)
             isCloseToGoal = goalDiff[0] <= 6 and goalDiff[1] <= 6
             while len(allLocations) and (
-                np.array_equal(agentLocation, self._goalLocation)
-                or not self._mazeArray[agentLocation[0]][agentLocation[1]]
-                or isCloseToGoal
+                np.array_equal(agentLocation, self._goalLocation) or isCloseToGoal
             ):
                 agentLocation = np.array(allLocations.pop())
                 goalDiff = np.abs(agentLocation - self._goalLocation)
@@ -114,10 +112,8 @@ class MazeEnv(gym.Env):
         return self._getObs(), self._get_info()
 
     def isValidLocation(self, location: np.ndarray):
-        return (
-            0 <= location[0] < len(self._mazeArray)
-            and 0 <= location[1] < len(self._mazeArray)
-            and self._map[location[0], location[1], 0] == 1
+        return 0 <= location[0] < len(self._mazeArray) and 0 <= location[1] < len(
+            self._mazeArray
         )
 
     def step(self, action):
@@ -143,11 +139,14 @@ class MazeEnv(gym.Env):
         else:
             reward = 0
 
-        agentLocationValue = self._mazeTracker[self._agentLocation[0]][
-            self._agentLocation[1]
-        ]
-        if isinstance(agentLocationValue, int) and agentLocationValue < 9:
-            self._mazeTracker[self._agentLocation[0]][self._agentLocation[1]] += 1
+        row = self._agentLocation[0]
+        column = self._agentLocation[1]
+        agentLocationValue = self._mazeTracker[row][column]
+        if agentLocationValue == "X":
+            self._mazeTracker[row][column] = 1
+        elif isinstance(agentLocationValue, int) and agentLocationValue < 9:
+            self._mazeTracker[row][column] += 1
+
         if (terminated or truncated) and self._debugging:
             print("Steps:", self._episode_len)
             print("Shortest:", self._shortestDistance)

--- a/environments.py
+++ b/environments.py
@@ -41,6 +41,11 @@ class MazeEnv(gym.Env):
             2: np.array([-1, 0]),
             3: np.array([0, -1]),
         }
+        self._visitCounts = [
+            [0 for j in range(self._actualMazeSize)]
+            for i in range(self._actualMazeSize)
+        ]
+        self.previousActions = None
 
     def _get_info(self):
         return {"location": self._agentLocation}
@@ -68,7 +73,8 @@ class MazeEnv(gym.Env):
         agentChannel = np.zeros([mazeSize, mazeSize, 1], dtype=np.int32)
         if not self._startLocation:
             allLocations = []
-            _range = range(self._mazeSize // 2, self._mazeSize // 2 + self._mazeSize)
+            shiftAmount = (self._actualMazeSize - self._mazeSize) // 2
+            _range = range(shiftAmount, shiftAmount + self._mazeSize)
             for i in _range:
                 for j in _range:
                     allLocations.append((i, j))
@@ -107,6 +113,7 @@ class MazeEnv(gym.Env):
         mazeChannel = np.expand_dims(self._mazeArray, axis=2)
         self._map = np.concat((mazeChannel, targetChannel, agentChannel), axis=2)
         self._episode_len = 0
+        self.previousActions = deque()
         if not self._maxSteps:
             self._maxSteps = self.getShortestDistance()
         return self._getObs(), self._get_info()
@@ -166,93 +173,10 @@ class MazeEnv(gym.Env):
                     renderOutput[i][j] = self._mazeTracker[i][j]
         return getMazeDebugString(renderOutput)
 
-
-class FoggedMazeEnv(MazeEnv):
-    def __init__(self, config=None):
-        super().__init__(config)
-        self._visualRange = config.get("visualRange", 4)
-        visualObsSize = self._visualRange * 2 + 1
-        self.observation_space = gym.spaces.MultiBinary(
-            (visualObsSize, visualObsSize, 2)
-        )
-
-    def _getObs(self):
-        paddedMap = np.pad(
-            self._map,
-            (
-                (self._visualRange, self._visualRange),
-                (self._visualRange, self._visualRange),
-                (0, 0),
-            ),
-            mode="constant",
-        )
-        _paddedAgentLoc = self._agentLocation + np.array((4, 4))
-        vision = paddedMap[
-            _paddedAgentLoc[0] - 4 : _paddedAgentLoc[0] + 5,
-            _paddedAgentLoc[1] - 4 : _paddedAgentLoc[1] + 5,
-            :,
-        ]
-        return vision[:, :, :2]
-
-
-class PlaceMazeEnv(FoggedMazeEnv):
-    def __init__(self, config=None):
-        super().__init__(config)
-        visualObsSize = self._visualRange * 2 + 1
-        self._lastLocation = self._agentLocation
-        self.observation_space = gym.spaces.Box(
-            0, self._mazeSize, (visualObsSize**2 * 2 + 4 + self.action_space.n + 1,)
-        )
-
-    def reset(self, *, seed: Optional[int] = None, options: Optional[dict] = None):
-        self._lastLocation = np.array([1, 1])
-        super().reset(seed=seed, options=options)
-        self._lastLocation = self._agentLocation
-        return self._getObs(), self._get_info()
-
-    def step(self, action):
-        self._lastLocation = self._agentLocation
-        return super().step(action)
-
-    def _getObs(self):
-        vision = super()._getObs()
-        actionOneHot = np.zeros(5)
-        actionOneHot[self._actionTaken] = 1
-        return np.concatenate(
-            [
-                vision.flatten(),
-                (self._lastLocation - self._mazeSize // 2) / self._mazeSize,
-                (self._lastLocation - self._mazeSize // 2) / self._mazeSize,
-                actionOneHot,
-            ],
-            dtype=np.float32,
-        )
-
-
-class SelfLocalizeEnv(PlaceMazeEnv):
-    def __init__(self, config=None):
-        super().__init__(config)
-        visualObsSize = self._visualRange * 2 + 1
-        self._lastLocation = self._agentLocation
-        self._lastAction = np.random.randint(0, 4)
-        self._visitCounts = [
-            [0 for j in range(self._actualMazeSize)]
-            for i in range(self._actualMazeSize)
-        ]
-        self.observation_space = gym.spaces.Box(
-            0, 1, (visualObsSize**2 * 2 + 4 + self.action_space.n + 1,)
-        )
-        self.previousActions = None
-
-    def reset(self, *, seed: Optional[int] = None, options: Optional[dict] = None):
-        super().reset(seed=seed)
-        self.previousActions = deque()
-        return self._getObs(), self._get_info()
-
-    def step(self, action):
+    def getSmoothRandomAction(self):
         """
-        Overrides the action. Forces agent to move in a directional manner that doesn't
-        end in jitter. It follows the following heuristics ranked by priority:
+        Produces random action inline with the agent moving in a directional manner
+        that doesn't end in jitter. It follows the following heuristics ranked by priority:
         1. Must not run into walls (prevent nullified movement)
         2. It cannot move in the opposite direction of any actions it made in the last
         three moves.
@@ -290,10 +214,105 @@ class SelfLocalizeEnv(PlaceMazeEnv):
         _, best_action = min(candidates, key=lambda x: x[0])
 
         self._lastLocation = self._agentLocation
-        self._lastAction = best_action
-        stepOutput = super().step(best_action)
         self._visitCounts[self._agentLocation[0]][self._agentLocation[1]] += 1
         self.previousActions.append(best_action)
         if len(self.previousActions) > 3:
             self.previousActions.popleft()
-        return stepOutput
+        return best_action
+
+
+class FoggedMazeEnv(MazeEnv):
+    def __init__(self, config=None):
+        super().__init__(config)
+        self._visualRange = config.get("visualRange", 4)
+        visualObsSize = self._visualRange * 2 + 1
+        self.observation_space = gym.spaces.MultiBinary(
+            (visualObsSize, visualObsSize, 2)
+        )
+
+    def _getObs(self):
+        paddedMap = np.pad(
+            self._map,
+            (
+                (self._visualRange, self._visualRange),
+                (self._visualRange, self._visualRange),
+                (0, 0),
+            ),
+            mode="constant",
+        )
+        _paddedAgentLoc = self._agentLocation + np.array((4, 4))
+        vision = paddedMap[
+            _paddedAgentLoc[0] - 4 : _paddedAgentLoc[0] + 5,
+            _paddedAgentLoc[1] - 4 : _paddedAgentLoc[1] + 5,
+            :,
+        ]
+        return vision[:, :, :2]
+
+
+class PlaceMazeEnv(FoggedMazeEnv):
+    def __init__(self, config=None):
+        super().__init__(config)
+        visualObsSize = self._visualRange * 2 + 1
+        self._lastLocation = self._agentLocation
+        self.observation_space = gym.spaces.Box(
+            0, 1, (visualObsSize**2 * 2 + 4 + self.action_space.n + 1,)
+        )
+
+    def reset(self, *, seed: Optional[int] = None, options: Optional[dict] = None):
+        self._lastLocation = np.array([1, 1])
+        super().reset(seed=seed, options=options)
+        self._lastLocation = self._agentLocation
+        return self._getObs(), self._get_info()
+
+    def step(self, action):
+        self._lastLocation = self._agentLocation
+        return super().step(action)
+
+    def _getObs(self):
+        vision = super()._getObs()
+        actionOneHot = np.zeros(5)
+        actionOneHot[self._actionTaken] = 1
+        return np.concatenate(
+            [
+                vision.flatten(),
+                (self._lastLocation - self._mazeSize // 2) / self._mazeSize,
+                (self._lastLocation - self._mazeSize // 2) / self._mazeSize,
+                actionOneHot,
+            ],
+            dtype=np.float32,
+        )
+
+
+class SelfLocalizeEnv(PlaceMazeEnv):
+    def __init__(self, config=None):
+        super().__init__(config)
+        visualObsSize = self._visualRange * 2 + 1
+        self._lastLocation = self._agentLocation
+        self.observation_space = gym.spaces.Box(
+            0, 1, (visualObsSize**2 * 2 + 4 + self.action_space.n + 1,)
+        )
+        self._actualMazeSize = self._mazeSize
+        self._goalLocation = [self._mazeSize // 2, self._mazeSize // 2]
+
+    def reset(self, *, seed: Optional[int] = None, options: Optional[dict] = None):
+        super().reset(seed=seed)
+        self.previousActions = deque()
+        return self._getObs(), self._get_info()
+
+    def step(self, action):
+        return super().step(self.getSmoothRandomAction())
+
+    def _getObs(self):
+        obs = super()._getObs()
+        actionOneHot = np.zeros(5)
+        actionOneHot[self._actionTaken] = 1
+        visualObsSize = self._visualRange * 2 + 1
+        return np.concatenate(
+            [
+                obs[: visualObsSize**2 * 2],
+                self._lastLocation / self._mazeSize,
+                self._lastLocation / self._mazeSize,
+                actionOneHot,
+            ],
+            dtype=np.float32,
+        )

--- a/environments.py
+++ b/environments.py
@@ -276,7 +276,7 @@ class PlaceMazeEnv(FoggedMazeEnv):
             [
                 vision.flatten(),
                 (self._lastLocation - self._mazeSize // 2) / self._mazeSize,
-                (self._lastLocation - self._mazeSize // 2) / self._mazeSize,
+                (self._agentLocation - self._mazeSize // 2) / self._mazeSize,
                 actionOneHot,
             ],
             dtype=np.float32,
@@ -311,7 +311,7 @@ class SelfLocalizeEnv(PlaceMazeEnv):
             [
                 obs[: visualObsSize**2 * 2],
                 self._lastLocation / self._mazeSize,
-                self._lastLocation / self._mazeSize,
+                self._agentLocation / self._mazeSize,
                 actionOneHot,
             ],
             dtype=np.float32,

--- a/models/agent_models.py
+++ b/models/agent_models.py
@@ -170,7 +170,7 @@ class PlaceMazeModule(MemoryMazeModule):
         candidateGrid: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         prevPlaces = self.placeEncoder(
-            calculatePlace(self.placeCells, lastAgentLocation)[:, 0, :]
+            calculatePlace(self.placeCells, lastAgentLocation, self.fieldSize)[:, 0, :]
         )
         actualHiddenGrid = prevPlaces[:, : self.integratorSize].contiguous()
         actualCandidateGrid = prevPlaces[:, self.integratorSize :].contiguous()
@@ -246,7 +246,9 @@ class PlaceMazeModule(MemoryMazeModule):
             },
             Columns.EMBEDDINGS: hiddenStates,
             "placeLogit": projectedPlace,
-            "placeTarget": calculatePlace(self.placeCells, agentLocation),
+            "placeTarget": calculatePlace(
+                self.placeCells, agentLocation, self.fieldSize
+            ),
             "placeCells": self.placeCells.unsqueeze(0)
             .unsqueeze(0)
             .expand([*projectedPlace.shape[:2], self.numPlaceCells, 2]),

--- a/models/utils.py
+++ b/models/utils.py
@@ -1,14 +1,13 @@
 import torch
-import math
 
 
 def calculatePlace(
     placeCells: torch.Tensor,
     agentLocation: torch.Tensor,
-    numPlaceCells: int = 32,
-    fieldSize: float = 0.3 / math.sqrt(32),
+    fieldSize: float = 0.06,
 ):
     with torch.no_grad():
+        numPlaceCells = placeCells.shape[0]
         agentLocationShape = agentLocation.shape
         agentLocation = agentLocation.flatten(0, -2)
         diff = agentLocation.unsqueeze(1) - placeCells.unsqueeze(0)

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,9 +51,10 @@ requests==2.32.3
 rpds-py==0.23.1
 scipy==1.17.1
 six==1.17.0
-sympy==1.13.1
+sympy==1.14.0
 tensorboardX==2.6.2.2
-torch==2.6.0
+torch==2.13.0
+torchvision==0.28.0
 typing-inspection==0.4.2
 typing_extensions==4.15.0
 tzdata==2025.1

--- a/train.py
+++ b/train.py
@@ -53,16 +53,7 @@ if __name__ == "__main__":
     if args.offlimit:
         maze = generateMazeWithOfflimit(mazeSize)
     elif args.selfLocalize:
-        maze = generateMaze(mazeSize * 2, 0)
-        for i in range(len(maze)):
-            for j in range(len(maze[0])):
-                if (
-                    mazeSize // 2 + mazeSize < i
-                    or i < mazeSize // 2
-                    or mazeSize // 2 + mazeSize < j
-                    or j < mazeSize // 2
-                ):
-                    maze[i][j] = 0
+        maze = generateMaze(mazeSize, 0)
     elif not args.randomMaze:
         if not os.path.exists(mazesPath):
             os.makedirs(mazesPath)

--- a/train.py
+++ b/train.py
@@ -54,6 +54,15 @@ if __name__ == "__main__":
         maze = generateMazeWithOfflimit(mazeSize)
     elif args.selfLocalize:
         maze = generateMaze(mazeSize * 2, 0)
+        for i in range(len(maze)):
+            for j in range(len(maze[0])):
+                if (
+                    mazeSize // 2 + mazeSize < i
+                    or i < mazeSize // 2
+                    or mazeSize // 2 + mazeSize < j
+                    or j < mazeSize // 2
+                ):
+                    maze[i][j] = 0
     elif not args.randomMaze:
         if not os.path.exists(mazesPath):
             os.makedirs(mazesPath)

--- a/train.py
+++ b/train.py
@@ -45,8 +45,6 @@ def usesGrid():
 
 if __name__ == "__main__":
     mazeSize = args.mazeSize
-    mazeDimension = (mazeSize, mazeSize)
-    goalLocation = (mazeSize // 2, mazeSize // 2)
     mazeName = args.mazeName
     mazesPath = "mazes"
     visionRange = 4
@@ -55,7 +53,7 @@ if __name__ == "__main__":
     if args.offlimit:
         maze = generateMazeWithOfflimit(mazeSize)
     elif args.selfLocalize:
-        maze = generateMaze(mazeSize, 0)
+        maze = generateMaze(mazeSize * 2, 0)
     elif not args.randomMaze:
         if not os.path.exists(mazesPath):
             os.makedirs(mazesPath)
@@ -95,7 +93,6 @@ if __name__ == "__main__":
 
     environmentConfig = {
         "maze": maze if maze else None,
-        "goal": None if args.fixedStart else goalLocation,
         "start": [mazeSize // 2, mazeSize // 2] if args.fixedStart else None,
         "maxSteps": args.maxSteps,
         "memoryLen": args.memoryLen,


### PR DESCRIPTION
### Issue
If you train an agent in a 30x30 environment and then expand it to 60x60, there is a shift in training distribution because they will no longer see the wall that is used to be so close to it.

### Fix
Train the agent using the 60x60 environment but only within the inner 30x30 area so that it will practically no longer encounter a wall. This is only done during training of policy inference. Self localization still uses the smaller environment with walls.

### Miscellaneous Changes

- Calculate place cell code fixed to square firing field. It wasn't before, causing the prediction error to be unusually low.
- The obstacles are now traversable. This simplifies interpretation of performance metric.