### PR TITLE
Latent path integration prototype/Revamp gated path integration module

### DIFF
--- a/environments.py
+++ b/environments.py
@@ -1,10 +1,10 @@
-from typing import Optional
-from collections import deque
-import numpy as np
-import gymnasium as gym
 import random
+from collections import deque
 
-from maze import getMazeDebugString, generateMaze
+import gymnasium as gym
+import numpy as np
+
+from maze import generateMaze, getMazeDebugString
 
 
 class MazeEnv(gym.Env):
@@ -21,6 +21,7 @@ class MazeEnv(gym.Env):
         self._actionTaken = 4
         self._debugging = config.get("debugging", None)
         self._mazeTracker = []
+        self._eval = config.get("eval", False)
 
         self._map = None
         self._agentLocation = (
@@ -56,7 +57,7 @@ class MazeEnv(gym.Env):
         else:
             return location + goal - 8
 
-    def reset(self, *, seed: Optional[int] = None, options: Optional[dict] = None):
+    def reset(self, *, seed: int | None = None, options: dict | None = None):
         super().reset(seed=seed)
         if self._randomMaze:
             self._mazeArray = generateMaze(self._actualMazeSize)
@@ -137,11 +138,14 @@ class MazeEnv(gym.Env):
         self._episode_len += 1
         truncated = self._episode_len > self._maxSteps
         if terminated:
-            if self._episode_len > 100:
-                reward = 0.1
+            if self._eval:
+                reward = 1
             else:
-                closenessFactor = 1 - self._episode_len / 100
-                reward = 0.1 + closenessFactor**2
+                if self._episode_len > 100:
+                    reward = 0.1
+                else:
+                    closenessFactor = 1 - self._episode_len / 100
+                    reward = 0.1 + closenessFactor**2
         else:
             reward = 0
 
@@ -224,7 +228,7 @@ class PlaceMazeEnv(FoggedMazeEnv):
             ):
                 return goal
 
-    def reset(self, *, seed: Optional[int] = None, options: Optional[dict] = None):
+    def reset(self, *, seed: int | None = None, options: dict | None = None):
         self._lastLocation = np.array([1, 1])
         if self._perturb:
             shiftAmount = (self._actualMazeSize - self._mazeSize) // 2
@@ -288,7 +292,7 @@ class SelfLocalizeEnv(PlaceMazeEnv):
         self._goalLocation = [self._mazeSize // 2, self._mazeSize // 2]
         self.previousActions = None
 
-    def reset(self, *, seed: Optional[int] = None, options: Optional[dict] = None):
+    def reset(self, *, seed: int | None = None, options: dict | None = None):
         super().reset(seed=seed)
         self.previousActions = deque()
         return self._getObs(), self._get_info()

--- a/environments.py
+++ b/environments.py
@@ -21,7 +21,6 @@ class MazeEnv(gym.Env):
         self._actionTaken = 4
         self._debugging = config.get("debugging", None)
         self._mazeTracker = []
-        self._shortestDistance = 0
 
         self._map = None
         self._agentLocation = (
@@ -156,7 +155,6 @@ class MazeEnv(gym.Env):
 
         if (terminated or truncated) and self._debugging:
             print("Steps:", self._episode_len)
-            print("Shortest:", self._shortestDistance)
             print(self.render())
         return self._getObs(), reward, terminated, truncated, self._get_info()
 

--- a/environments.py
+++ b/environments.py
@@ -165,7 +165,7 @@ class MazeEnv(gym.Env):
         ]
         for i in range(self._actualMazeSize):
             for j in range(self._actualMazeSize):
-                if not self._mazeTracker[i][j]:
+                if not self._mazeTracker[i][j] or self._mazeTracker[i][j] == "X":
                     renderOutput[i][j] = " "
                 else:
                     renderOutput[i][j] = self._mazeTracker[i][j]

--- a/eval.py
+++ b/eval.py
@@ -18,8 +18,9 @@ parser.add_argument("--grid", action="store_true")
 parser.add_argument("--memoryLen", type=int, default=20)
 parser.add_argument("--latentPath", action="store_true")
 parser.add_argument("--pretraining", action="store_true")
-parser.add_argument("--pureCode", action="store_true")
 parser.add_argument("--perturb", action="store_true")
+parser.add_argument("--visionPolicy", action="store_true")
+parser.add_argument("--integrationPolicy", action="store_true")
 args = parser.parse_args()
 
 if args.pretraining:
@@ -27,7 +28,7 @@ if args.pretraining:
 
 
 def usesGrid():
-    return args.grid or args.selfLocalize or args.latentPath or args.pureCode
+    return args.grid or args.selfLocalize or args.latentPath or args.integrationPolicy
 
 
 if __name__ == "__main__":
@@ -38,8 +39,6 @@ if __name__ == "__main__":
         module = models.PathIntegrationWithVisionModuleForEval
         if args.latentPath:
             module = models.LatentPathModule
-        elif args.pureCode:
-            module = models.PureCodeModule
     else:
         module = models.PlaceCellControlModule
 
@@ -48,10 +47,11 @@ if __name__ == "__main__":
     environmentConfig = {
         "maze": None,
         "start": None,
-        "maxSteps": args.maxSteps,
+        "maxSteps": 300,
         "memoryLen": args.memoryLen,
         "mazeSize": mazeSize,
         "perturb": args.perturb,
+        "eval": True,
     }
 
     agentConfig = (
@@ -69,6 +69,8 @@ if __name__ == "__main__":
                     "inputSize": visionRange * 2 + 1,
                     "max_seq_len": args.memoryLen,
                     "mazeSize": mazeSize,
+                    "visionPolicy": args.visionPolicy,
+                    "integrationPolicy": args.integrationPolicy,
                 },
             ),
         )

--- a/eval.py
+++ b/eval.py
@@ -21,6 +21,7 @@ parser.add_argument("--pretraining", action="store_true")
 parser.add_argument("--perturb", action="store_true")
 parser.add_argument("--visionPolicy", action="store_true")
 parser.add_argument("--integrationPolicy", action="store_true")
+parser.add_argument("--debug", type=int, default=0)
 args = parser.parse_args()
 
 if args.pretraining:
@@ -28,7 +29,7 @@ if args.pretraining:
 
 
 def usesGrid():
-    return args.grid or args.selfLocalize or args.latentPath or args.integrationPolicy
+    return args.grid or args.latentPath or args.integrationPolicy
 
 
 if __name__ == "__main__":
@@ -52,6 +53,7 @@ if __name__ == "__main__":
         "mazeSize": mazeSize,
         "perturb": args.perturb,
         "eval": True,
+        "debugging": args.debug,
     }
 
     agentConfig = (
@@ -76,9 +78,9 @@ if __name__ == "__main__":
         )
         .learners(num_gpus_per_learner=1 if torch.cuda.is_available() else 0)
         .evaluation(
-            evaluation_num_env_runners=8,
+            evaluation_num_env_runners=1 if args.debug else 8,
             evaluation_duration_unit="episodes",
-            evaluation_duration=128,
+            evaluation_duration=1 if args.debug else 128,
         )
     )
     agentConfig.env_config = environmentConfig
@@ -87,15 +89,19 @@ if __name__ == "__main__":
     if os.path.exists(checkpointPath):
         agent.restore_from_path(checkpointPath)
 
-    numSamples = 10
-    averageReturn = 0
-    averageSteps = 0
-    for j in range(numSamples):
-        result = agent.evaluate()["env_runners"]
-        averageReturn += result["episode_return_mean"]
-        averageSteps += result["episode_len_mean"]
-    averageReturn = round(averageReturn / numSamples, 2)
-    print("Performance:", averageReturn)
-    averageSteps = round(averageSteps / numSamples, 0)
-    print("Steps:", averageSteps)
-    numSamples = int((args.maxSteps - averageSteps) / args.maxSteps * 10) + 1
+    if args.debug:
+        for i in range(args.debug):
+            agent.evaluate()
+    else:
+        numSamples = 10
+        averageReturn = 0
+        averageSteps = 0
+        for j in range(numSamples):
+            result = agent.evaluate()["env_runners"]
+            averageReturn += result["episode_return_mean"]
+            averageSteps += result["episode_len_mean"]
+        averageReturn = round(averageReturn / numSamples, 2)
+        print("Performance:", averageReturn)
+        averageSteps = round(averageSteps / numSamples, 0)
+        print("Steps:", averageSteps)
+        numSamples = int((args.maxSteps - averageSteps) / args.maxSteps * 10) + 1

--- a/eval.py
+++ b/eval.py
@@ -1,0 +1,99 @@
+import argparse
+import os
+
+import torch
+from ray.rllib.algorithms.ppo import PPOConfig
+from ray.rllib.core.rl_module.rl_module import RLModuleSpec
+
+import models
+from environments import PlaceMazeEnv
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--mazeSize", type=int, default=30)
+parser.add_argument("--hiddenSize", type=int, default=32)
+parser.add_argument("--numLayers", type=int, default=2)
+parser.add_argument("--maxSteps", type=int, default=1000)
+parser.add_argument("--expName", type=str, default="default_exp")
+parser.add_argument("--grid", action="store_true")
+parser.add_argument("--memoryLen", type=int, default=20)
+parser.add_argument("--latentPath", action="store_true")
+parser.add_argument("--pretraining", action="store_true")
+parser.add_argument("--pureCode", action="store_true")
+parser.add_argument("--perturb", action="store_true")
+args = parser.parse_args()
+
+if args.pretraining:
+    args.latentPath = True
+
+
+def usesGrid():
+    return args.grid or args.selfLocalize or args.latentPath or args.pureCode
+
+
+if __name__ == "__main__":
+    mazeSize = args.mazeSize
+    visionRange = 4
+
+    if usesGrid():
+        module = models.PathIntegrationWithVisionModuleForEval
+        if args.latentPath:
+            module = models.LatentPathModule
+        elif args.pureCode:
+            module = models.PureCodeModule
+    else:
+        module = models.PlaceCellControlModule
+
+    env = PlaceMazeEnv
+
+    environmentConfig = {
+        "maze": None,
+        "start": None,
+        "maxSteps": args.maxSteps,
+        "memoryLen": args.memoryLen,
+        "mazeSize": mazeSize,
+        "perturb": args.perturb,
+    }
+
+    agentConfig = (
+        PPOConfig()
+        .environment(env)
+        .api_stack(
+            enable_rl_module_and_learner=True, enable_env_runner_and_connector_v2=True
+        )
+        .rl_module(
+            rl_module_spec=RLModuleSpec(
+                module_class=module,
+                model_config={
+                    "hiddenSize": args.hiddenSize,
+                    "numLayers": args.numLayers,
+                    "inputSize": visionRange * 2 + 1,
+                    "max_seq_len": args.memoryLen,
+                    "mazeSize": mazeSize,
+                },
+            ),
+        )
+        .learners(num_gpus_per_learner=1 if torch.cuda.is_available() else 0)
+        .evaluation(
+            evaluation_num_env_runners=8,
+            evaluation_duration_unit="episodes",
+            evaluation_duration=128,
+        )
+    )
+    agentConfig.env_config = environmentConfig
+    agent = agentConfig.build_algo()
+    checkpointPath = f"{os.path.abspath(os.getcwd())}/checkpoints/{args.expName}"
+    if os.path.exists(checkpointPath):
+        agent.restore_from_path(checkpointPath)
+
+    numSamples = 10
+    averageReturn = 0
+    averageSteps = 0
+    for j in range(numSamples):
+        result = agent.evaluate()["env_runners"]
+        averageReturn += result["episode_return_mean"]
+        averageSteps += result["episode_len_mean"]
+    averageReturn = round(averageReturn / numSamples, 2)
+    print("Performance:", averageReturn)
+    averageSteps = round(averageSteps / numSamples, 0)
+    print("Steps:", averageSteps)
+    numSamples = int((args.maxSteps - averageSteps) / args.maxSteps * 10) + 1

--- a/learners/ppo_grid_learner.py
+++ b/learners/ppo_grid_learner.py
@@ -44,7 +44,8 @@ class PPOTorchLearnerWithSelfPredLoss(PPOTorchLearner):
                     "bmp,mpd->bmd", placeTarget, placeCells
                 )
 
-                # Reconstruction Loss
+            # Reconstruction Loss
+            if "actualLatents" in fwd_out and "reconstructedLatents" in fwd_out:
                 latents: torch.Tensor = fwd_out["actualLatents"][lossMask]
                 reconstructedLatents: torch.Tensor = fwd_out["reconstructedLatents"][
                     lossMask
@@ -58,6 +59,20 @@ class PPOTorchLearnerWithSelfPredLoss(PPOTorchLearner):
                     window=100,
                 )
                 loss += reconstructionLoss
+
+            if "movements" in fwd_out:
+                movements: torch.Tensor = fwd_out["movements"][lossMask]
+                distances = torch.linalg.norm(movements, dim=1)
+                idealMovement = 1 / 30
+                movement_loss = torch.mean(
+                    ((distances - idealMovement) / idealMovement) ** 2
+                )
+                loss += movement_loss
+                self.metrics.log_value(
+                    key=(module_id, "movement_loss"),
+                    value=movement_loss.cpu().detach().numpy(),
+                    window=100,
+                )
 
             positionError = torch.mean(
                 torch.sqrt(

--- a/learners/ppo_grid_learner.py
+++ b/learners/ppo_grid_learner.py
@@ -63,9 +63,9 @@ class PPOTorchLearnerWithSelfPredLoss(PPOTorchLearner):
             if "movements" in fwd_out:
                 movements: torch.Tensor = fwd_out["movements"][lossMask]
                 distances = torch.linalg.norm(movements, dim=1)
-                idealMovement = 1 / 30
+                idealDistance = 1 / 30
                 movement_loss = torch.mean(
-                    ((distances - idealMovement) / idealMovement) ** 2
+                    ((distances - idealDistance) / idealDistance) ** 2
                 )
                 loss += movement_loss
                 self.metrics.log_value(

--- a/learners/ppo_grid_learner.py
+++ b/learners/ppo_grid_learner.py
@@ -1,11 +1,8 @@
-from typing import Any, Dict
-
+import torch
 from ray.rllib.algorithms.ppo import PPOConfig
 from ray.rllib.algorithms.ppo.torch.ppo_torch_learner import PPOTorchLearner
 from ray.rllib.utils.annotations import override
 from ray.rllib.utils.typing import ModuleID
-
-import torch
 
 
 class PPOTorchLearnerWithSelfPredLoss(PPOTorchLearner):
@@ -15,8 +12,8 @@ class PPOTorchLearnerWithSelfPredLoss(PPOTorchLearner):
         *,
         module_id: ModuleID,
         config: PPOConfig,
-        batch: Dict[str, Any],
-        fwd_out: Dict[str, torch.Tensor],
+        batch: dict[str, dict],
+        fwd_out: dict[str, torch.Tensor],
     ):
         if config.learner_config_dict.get("self_localize"):
             loss = 0

--- a/learners/ppo_grid_learner.py
+++ b/learners/ppo_grid_learner.py
@@ -63,7 +63,7 @@ class PPOTorchLearnerWithSelfPredLoss(PPOTorchLearner):
             if "movements" in fwd_out:
                 movements: torch.Tensor = fwd_out["movements"][lossMask]
                 distances = torch.linalg.norm(movements, dim=1)
-                idealDistance = 1 / 30
+                idealDistance = torch.mean(distances).detach()
                 movement_loss = torch.mean(
                     ((distances - idealDistance) / idealDistance) ** 2
                 )

--- a/maze.py
+++ b/maze.py
@@ -36,22 +36,12 @@ def generateDeprecatedMaze(dimensions: tuple[int], goal: tuple[int]):
     return maze
 
 
-def generateMaze(size: int, p_obstacle: float = 0.02):
+def generateMaze(size: int, p_obstacle: float = 0.2):
     maze = [[1 for _ in range(size)] for _ in range(size)]
     for i in range(size):
         for j in range(size):
             if random.random() < p_obstacle:
-                obstacleHeight = random.randint(1, 4)
-                obstacleWidth = random.randint(1, 4)
-                if (
-                    i <= size // 2 < i + obstacleHeight
-                    and j <= size // 2 < j + obstacleWidth
-                ):
-                    continue
-                for x in range(obstacleWidth):
-                    for y in range(obstacleHeight):
-                        if -1 < i + y < size and -1 < j + x < size:
-                            maze[i + y][j + x] = 0
+                maze[i][j] = 0
     return maze
 
 

--- a/models/agent_models.py
+++ b/models/agent_models.py
@@ -218,11 +218,16 @@ class PlaceMazeModule(MemoryMazeModule):
             batch
         )
         if policyInput is None or visualMemory is None:
+            obs = batch["obs"]
             policy = torch.randn(
-                [*agentLocation.shape[:2], self.action_space.n], dtype=torch.float32
+                [*agentLocation.shape[:2], self.action_space.n],
+                dtype=torch.float32,
+                device=obs.device,
             )
             visualMemory = torch.randn(
-                [*agentLocation.shape[:2], self.linearHiddenSize], dtype=torch.float32
+                [*agentLocation.shape[:2], self.linearHiddenSize],
+                dtype=torch.float32,
+                device=obs.device,
             )
         return {
             Columns.ACTION_DIST_INPUTS: policy,
@@ -249,6 +254,7 @@ class PlaceMazeModule(MemoryMazeModule):
                 embeddings = torch.randn(
                     [*batch["obs"].shape[:2], self.linearHiddenSize],
                     dtype=torch.float32,
+                    device=batch["obs"].device,
                 )
         return self.value_branch(embeddings).squeeze(-1)
 

--- a/models/agent_models.py
+++ b/models/agent_models.py
@@ -327,14 +327,7 @@ class PathIntegrationWithVisionModuleForEval(PathIntegrationWithVisionModule):
             memory = getVisualMemory()
             integration = self.gridCompressor(gridCodes)
             visualPolicy = self.policy_branch(memory)
-            integrationPolicy = self.policy_branch(integration)
-            visualConfidence = (
-                torch.nn.functional.softmax(visualPolicy, -1)
-                .flatten()
-                .topk(2)
-                .values.sum()
-                .item()
-            )
+            integrationPolicy = self.piPolicyPredictor(integration)
             integrationConfidence = (
                 torch.nn.functional.softmax(integrationPolicy, -1)
                 .flatten()
@@ -342,7 +335,8 @@ class PathIntegrationWithVisionModuleForEval(PathIntegrationWithVisionModule):
                 .values.sum()
                 .item()
             )
-            if visualConfidence > integrationConfidence:
+
+            if integrationConfidence < 0.8:
                 policy = visualPolicy
             else:
                 policy = integrationPolicy

--- a/models/agent_models.py
+++ b/models/agent_models.py
@@ -91,7 +91,7 @@ class MemoryMazeModule(SimpleMazeModule):
         return self.value_branch(self._processPreHeads(batch)[0]).squeeze(-1)
 
 
-class PlaceMazeModule(MemoryMazeModule):
+class PathIntegrationWithVisionModule(MemoryMazeModule):
     def setup(self):
         MemoryMazeModule.setup(self)
         self.mazeSize = self.model_config.get("mazeSize", 31)

--- a/models/agent_models.py
+++ b/models/agent_models.py
@@ -190,65 +190,32 @@ class PathIntegrationWithVisionModule(MemoryMazeModule):
         return memory
 
     def _getPolicyAndValue(self, batch):
-        vision, lastAgentLocation, _, action = self._getObsFromBatch(batch)
-        gridCodes, projectedPlace, finalIntegrationState = self._pathIntegrate(
-            lastAgentLocation[:, 0, :],
-            action,
-            batch[Columns.STATE_IN]["hiddenGrid"],
-            batch[Columns.STATE_IN]["candidateGrid"],
-        )
-
         memory = None
         value = None
         policy = None
 
-        if not self.model_config.get("self_localize", False):
+        vision, lastAgentLocation, _, action = self._getObsFromBatch(batch)
+
+        selfLocalize = self.model_config.get("self_localize", False)
+        useVisionPolicy = self.model_config.get("visionPolicy", False)
+        if selfLocalize or not useVisionPolicy:
+            gridCodes, projectedPlace, finalIntegrationState = self._pathIntegrate(
+                lastAgentLocation[:, 0, :],
+                action,
+                batch[Columns.STATE_IN]["hiddenGrid"],
+                batch[Columns.STATE_IN]["candidateGrid"],
+            )
+            if not selfLocalize:
+                integration = self.gridCompressor(gridCodes)
+                policy = self.piPolicyPredictor(integration)
+                value = self.piValuePredictor(integration)
+        elif useVisionPolicy:
             initialState = self._getInitialMemory(
                 lastAgentLocation[:, 0, :], batch[Columns.STATE_IN]["hiddenObs"]
             )
             memory = self._processVisualMemory(vision, initialState)
-            if self.training:
-                integration = self.gridCompressor(gridCodes)
-                controlSelector = (
-                    torch.rand(
-                        [*memory.shape[:2], 1],
-                        device=memory.device,
-                        dtype=torch.float32,
-                    )
-                    < 0.75
-                )
-                policy = torch.where(
-                    controlSelector,
-                    self.policy_branch(memory),
-                    self.piPolicyPredictor(integration),
-                )
-                value = torch.where(
-                    controlSelector,
-                    self.value_branch(memory),
-                    self.piValuePredictor(integration),
-                )
-            else:
-                integration = self.gridCompressor(gridCodes)
-                visualPolicy = self.policy_branch(memory)
-                integrationPolicy = self.policy_branch(integration)
-                visualConfidence = (
-                    torch.nn.functional.softmax(visualPolicy, -1)
-                    .flatten()
-                    .topk(2)
-                    .values.sum()
-                    .item()
-                )
-                integrationConfidence = (
-                    torch.nn.functional.softmax(integrationPolicy, -1)
-                    .flatten()
-                    .topk(2)
-                    .values.sum()
-                    .item()
-                )
-                if visualConfidence > integrationConfidence:
-                    policy = visualPolicy
-                else:
-                    policy = integrationPolicy
+            policy = self.policy_branch(memory)
+            value = self.value_branch(memory)
 
         return (
             policy,
@@ -284,7 +251,7 @@ class PathIntegrationWithVisionModule(MemoryMazeModule):
                 [*obs.shape[:2], 1], dtype=torch.float32, device=obs.device
             )
 
-        return {
+        output = {
             Columns.ACTION_DIST_INPUTS: policy,
             Columns.STATE_OUT: {
                 "hiddenObs": visualMemory[:, -1],
@@ -292,11 +259,15 @@ class PathIntegrationWithVisionModule(MemoryMazeModule):
                 "hiddenGrid": finalGrid[0].squeeze(0),
             },
             Columns.EMBEDDINGS: value,
-            "placeLogit": projectedPlace,
-            "placeTarget": calculatePlace(
-                self.placeCells, agentLocation, self.fieldSize
-            ),
         }
+
+        if self.model_config.get("self_localize", False):
+            output["placeLogit"] = projectedPlace
+            output["placeTarget"] = calculatePlace(
+                self.placeCells, agentLocation, self.fieldSize
+            )
+
+        return output
 
     @override(ValueFunctionAPI)
     def compute_values(self, batch, embeddings=None):
@@ -308,6 +279,59 @@ class PathIntegrationWithVisionModule(MemoryMazeModule):
                     [*obs.shape[:2]], dtype=torch.float32, device=obs.device
                 )
         return embeddings.squeeze(-1)
+
+
+class PathIntegrationWithVisionModuleForEval(PathIntegrationWithVisionModule):
+    def setup(self):
+        PathIntegrationWithVisionModule.setup(self)
+
+    def _getPolicyAndValue(self, batch):
+        assert not self.training, (
+            '"PathIntegrationWithVisionModuleForEval" cannot be used for training'
+        )
+
+        vision, lastAgentLocation, _, action = self._getObsFromBatch(batch)
+        gridCodes, _, finalIntegrationState = self._pathIntegrate(
+            lastAgentLocation[:, 0, :],
+            action,
+            batch[Columns.STATE_IN]["hiddenGrid"],
+            batch[Columns.STATE_IN]["candidateGrid"],
+        )
+
+        initialState = self._getInitialMemory(
+            lastAgentLocation[:, 0, :], batch[Columns.STATE_IN]["hiddenObs"]
+        )
+        memory = self._processVisualMemory(vision, initialState)
+
+        integration = self.gridCompressor(gridCodes)
+        visualPolicy = self.policy_branch(memory)
+        integrationPolicy = self.policy_branch(integration)
+        visualConfidence = (
+            torch.nn.functional.softmax(visualPolicy, -1)
+            .flatten()
+            .topk(2)
+            .values.sum()
+            .item()
+        )
+        integrationConfidence = (
+            torch.nn.functional.softmax(integrationPolicy, -1)
+            .flatten()
+            .topk(2)
+            .values.sum()
+            .item()
+        )
+        if visualConfidence > integrationConfidence:
+            policy = visualPolicy
+        else:
+            policy = integrationPolicy
+
+        return (
+            policy,
+            None,
+            memory,
+            None,
+            finalIntegrationState,
+        )
 
 
 class GPSModule(MemoryMazeModule):

--- a/models/agent_models.py
+++ b/models/agent_models.py
@@ -195,11 +195,8 @@ class PlaceMazeModule(MemoryMazeModule):
             batch[Columns.STATE_IN]["candidateGrid"],
         )
         if self.model_config.get("self_localize", False):
-            policyShape = [*gridCodes.shape[:2], self.linearHiddenSize]
-            policyInput = torch.randn(
-                policyShape, dtype=gridCodes.dtype, device=gridCodes.device
-            )
-            memory = policyInput
+            policyInput = None
+            memory = None
         else:
             initialState = self._getInitialMemory(
                 lastAgentLocation[:, 0, :], batch[Columns.STATE_IN]["hiddenObs"]
@@ -214,34 +211,27 @@ class PlaceMazeModule(MemoryMazeModule):
             finalIntegrationState,
         )
 
-    def _forward_exploration(self, batch, **kwargs):
-        policyInput, hiddenStates, _, finalGrid = self._processPreHeads(batch)
-        policy = self.policy_branch(policyInput)
-        return {
-            Columns.ACTION_DIST_INPUTS: policy,
-            Columns.STATE_OUT: {
-                "hiddenObs": hiddenStates[:, -1],
-                "candidateGrid": finalGrid[1].squeeze(0),
-                "hiddenGrid": finalGrid[0].squeeze(0),
-            },
-            Columns.EMBEDDINGS: hiddenStates,
-        }
-
     @override(TorchRLModule)
     def _forward(self, batch, **kwargs):
         _, _, agentLocation, _ = self._getObsFromBatch(batch)
-        policyInput, hiddenStates, projectedPlace, finalGrid = self._processPreHeads(
+        policyInput, visualMemory, projectedPlace, finalGrid = self._processPreHeads(
             batch
         )
-        policy = self.policy_branch(policyInput)
+        if policyInput is None or visualMemory is None:
+            policy = torch.randn(
+                [*agentLocation.shape[:2], self.action_space.n], dtype=torch.float32
+            )
+            visualMemory = torch.randn(
+                [*agentLocation.shape[:2], self.linearHiddenSize], dtype=torch.float32
+            )
         return {
             Columns.ACTION_DIST_INPUTS: policy,
             Columns.STATE_OUT: {
-                "hiddenObs": hiddenStates[:, -1],
+                "hiddenObs": visualMemory[:, -1],
                 "candidateGrid": finalGrid[1].squeeze(0),
                 "hiddenGrid": finalGrid[0].squeeze(0),
             },
-            Columns.EMBEDDINGS: hiddenStates,
+            Columns.EMBEDDINGS: visualMemory,
             "placeLogit": projectedPlace,
             "placeTarget": calculatePlace(
                 self.placeCells, agentLocation, self.fieldSize
@@ -255,6 +245,11 @@ class PlaceMazeModule(MemoryMazeModule):
     def compute_values(self, batch, embeddings=None):
         if embeddings is None:
             embeddings, _, _, _ = self._processPreHeads(batch)
+            if embeddings is None:
+                embeddings = torch.randn(
+                    [*batch["obs"].shape[:2], self.linearHiddenSize],
+                    dtype=torch.float32,
+                )
         return self.value_branch(embeddings).squeeze(-1)
 
 

--- a/models/agent_models.py
+++ b/models/agent_models.py
@@ -202,10 +202,10 @@ class PlaceMazeModule(MemoryMazeModule):
         integratedStates, finalIntegrationState = self.pathIntegrator(
             action, (actualHiddenGrid.unsqueeze(0), actualCandidateGrid.unsqueeze(0))
         )
-        decodedCode = self.gridDecoder.forward(integratedStates)
-        projectedPlace = self.placeProjector(decodedCode)
+        integratedCode = self.gridDecoder.forward(integratedStates)
+        projectedPlace = self.placeProjector(integratedCode)
         return (
-            decodedCode.detach(),
+            integratedCode.detach(),
             projectedPlace,
             finalIntegrationState,
         )

--- a/models/agent_models.py
+++ b/models/agent_models.py
@@ -193,6 +193,8 @@ class PathIntegrationWithVisionModule(MemoryMazeModule):
         memory = None
         value = None
         policy = None
+        projectedPlace = None
+        finalIntegrationState = None
 
         vision, lastAgentLocation, _, action = self._getObsFromBatch(batch)
 
@@ -255,8 +257,12 @@ class PathIntegrationWithVisionModule(MemoryMazeModule):
             Columns.ACTION_DIST_INPUTS: policy,
             Columns.STATE_OUT: {
                 "hiddenObs": visualMemory[:, -1],
-                "candidateGrid": finalGrid[1].squeeze(0),
-                "hiddenGrid": finalGrid[0].squeeze(0),
+                "candidateGrid": finalGrid[1].squeeze(0)
+                if finalGrid is not None
+                else batch[Columns.STATE_IN]["candidateGrid"],
+                "hiddenGrid": finalGrid[0].squeeze(0)
+                if finalGrid is not None
+                else batch[Columns.STATE_IN]["hiddenGrid"],
             },
             Columns.EMBEDDINGS: value,
         }

--- a/models/agent_models.py
+++ b/models/agent_models.py
@@ -113,36 +113,6 @@ class PlaceMazeModule(MemoryMazeModule):
             self.numPlaceCells, self.linearHiddenSize
         )
 
-    """
-    Following code is used to figure out how dramatically place code can change
-    between moving squares.
-
-    def _calculatePlace(self, agentLocation: torch.Tensor):
-        coordinates = [[[i, j] for i in range(31)] for j in range(31)]
-        coordinates = torch.tensor(coordinates, dtype=torch.float32)
-        coordinates = coordinates / 30
-        coordinates = coordinates.flatten(0, -2)
-        with torch.no_grad():
-            agentLocationShape = agentLocation.shape
-            agentLocation = coordinates
-            diff = agentLocation.unsqueeze(1) - self.placeCells.unsqueeze(0)
-            dists_squared = torch.sum(torch.abs(diff) ** 2, dim=-1)
-            unnormalized_activations = -dists_squared / (2 * self.fieldSize**2)
-            normalized_activations = torch.nn.functional.softmax(
-                unnormalized_activations, dim=1
-            )
-            normDiff = normalized_activations.unsqueeze(
-                1
-            ) - normalized_activations.unsqueeze(0)
-            normDiffSum = torch.sum(torch.abs(normDiff), dim=2)
-            sorted, _ = torch.sort(normDiffSum)
-            print(torch.round(torch.mean(sorted, dim=0), decimals=2)[:20])
-            raise Exception("dogshit")
-            return normalized_activations.reshape(
-                [*agentLocationShape[:2], self.numPlaceCells]
-            )
-    """
-
     @override(TorchRLModule)
     def get_initial_state(self):
         return {

--- a/models/agent_models.py
+++ b/models/agent_models.py
@@ -115,6 +115,9 @@ class PlaceMazeModule(MemoryMazeModule):
         self.placeCells = nn.Parameter(torch.rand([self.numPlaceCells, 2]), False)
         self.fieldSize = 0.3 / math.sqrt(self.numPlaceCells)
         self.placeEncoder = nn.Linear(self.numPlaceCells, 2 * self.integratorSize)
+        self.placeEncoderForMemory = nn.Linear(
+            self.numPlaceCells, self.linearHiddenSize
+        )
 
     """
     Following code is used to figure out how dramatically place code can change
@@ -176,7 +179,7 @@ class PlaceMazeModule(MemoryMazeModule):
         candidateGrid: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         prevPlaces = self.placeEncoder(
-            calculatePlace(self.placeCells, lastAgentLocation, self.fieldSize)[:, 0, :]
+            calculatePlace(self.placeCells, lastAgentLocation, self.fieldSize)
         )
         actualHiddenGrid = prevPlaces[:, : self.integratorSize].contiguous()
         actualCandidateGrid = prevPlaces[:, self.integratorSize :].contiguous()
@@ -196,21 +199,33 @@ class PlaceMazeModule(MemoryMazeModule):
             actualCandidateGrid = torch.where(
                 placeMask, candidatePlace, actualCandidateGrid
             )
-        gridStates, finalGridState = self.pathIntegrator(
+        integratedStates, finalIntegrationState = self.pathIntegrator(
             action, (actualHiddenGrid.unsqueeze(0), actualCandidateGrid.unsqueeze(0))
         )
-        decodedGrid = self.gridDecoder.forward(gridStates)
-        projectedPlace = self.placeProjector(decodedGrid)
+        decodedCode = self.gridDecoder.forward(integratedStates)
+        projectedPlace = self.placeProjector(decodedCode)
         return (
-            decodedGrid.detach(),
+            decodedCode.detach(),
             projectedPlace,
-            finalGridState,
+            finalIntegrationState,
         )
+
+    def _getInitialMemory(self, lastLocation: torch.Tensor, memoryState: torch.Tensor):
+        prevPlaces = self.placeEncoderForMemory(
+            calculatePlace(self.placeCells, lastLocation)
+        )
+        initialPlaceMask = torch.sum(memoryState, 1) == 0
+        return torch.where(initialPlaceMask[:, None], prevPlaces, memoryState)
+
+    def _processVisualMemory(self, vision: torch.Tensor, initialHidden: torch.Tensor):
+        visionFeatures = self._processConvolution(vision)
+        memory, _ = self.trajectoryMemory(visionFeatures, initialHidden.unsqueeze(0))
+        return memory
 
     def _processPreHeads(self, batch):
         vision, lastAgentLocation, _, action = self._getObsFromBatch(batch)
-        gridCodes, projectedPlace, finalGridState = self._pathIntegrate(
-            lastAgentLocation,
+        gridCodes, projectedPlace, finalIntegrationState = self._pathIntegrate(
+            lastAgentLocation[:, 0, :],
             action,
             batch[Columns.STATE_IN]["hiddenGrid"],
             batch[Columns.STATE_IN]["candidateGrid"],
@@ -222,9 +237,10 @@ class PlaceMazeModule(MemoryMazeModule):
             )
             memory = policyInput
         else:
-            visionFeatures = self._processConvolution(vision)
-            initialHidden = batch[Columns.STATE_IN]["hiddenObs"].unsqueeze(0)
-            memory = self.trajectoryMemory(visionFeatures, initialHidden)[0]
+            initialState = self._getInitialMemory(
+                lastAgentLocation[:, 0, :], batch[Columns.STATE_IN]["hiddenObs"]
+            )
+            memory = self._processVisualMemory(vision, initialState)
             gate = self.gridGate(memory.detach())
             policyInput = memory * (1 - gate) + self.gridCompressor(gridCodes) * gate
 
@@ -232,7 +248,7 @@ class PlaceMazeModule(MemoryMazeModule):
             policyInput,
             memory,
             projectedPlace,
-            finalGridState,
+            finalIntegrationState,
         )
 
     def _forward_exploration(self, batch, **kwargs):

--- a/models/agent_models.py
+++ b/models/agent_models.py
@@ -297,39 +297,55 @@ class PathIntegrationWithVisionModuleForEval(PathIntegrationWithVisionModule):
         )
 
         vision, lastAgentLocation, _, action = self._getObsFromBatch(batch)
-        gridCodes, _, finalIntegrationState = self._pathIntegrate(
-            lastAgentLocation[:, 0, :],
-            action,
-            batch[Columns.STATE_IN]["hiddenGrid"],
-            batch[Columns.STATE_IN]["candidateGrid"],
-        )
 
-        initialState = self._getInitialMemory(
-            lastAgentLocation[:, 0, :], batch[Columns.STATE_IN]["hiddenObs"]
-        )
-        memory = self._processVisualMemory(vision, initialState)
+        def getIntegration():
+            return self._pathIntegrate(
+                lastAgentLocation[:, 0, :],
+                action,
+                batch[Columns.STATE_IN]["hiddenGrid"],
+                batch[Columns.STATE_IN]["candidateGrid"],
+            )
 
-        integration = self.gridCompressor(gridCodes)
-        visualPolicy = self.policy_branch(memory)
-        integrationPolicy = self.policy_branch(integration)
-        visualConfidence = (
-            torch.nn.functional.softmax(visualPolicy, -1)
-            .flatten()
-            .topk(2)
-            .values.sum()
-            .item()
-        )
-        integrationConfidence = (
-            torch.nn.functional.softmax(integrationPolicy, -1)
-            .flatten()
-            .topk(2)
-            .values.sum()
-            .item()
-        )
-        if visualConfidence > integrationConfidence:
-            policy = visualPolicy
+        def getVisualMemory():
+            initialState = self._getInitialMemory(
+                lastAgentLocation[:, 0, :], batch[Columns.STATE_IN]["hiddenObs"]
+            )
+            return self._processVisualMemory(vision, initialState)
+
+        memory = None
+        finalIntegrationState = None
+
+        if self.model_config.get("visionPolicy", False):
+            memory = getVisualMemory()
+            policy = self.policy_branch(memory)
+        elif self.model_config.get("integrationPolicy", False):
+            gridCodes, _, finalIntegrationState = getIntegration()
+            integration = self.gridCompressor(gridCodes)
+            policy = self.piPolicyPredictor(integration)
         else:
-            policy = integrationPolicy
+            gridCodes, _, finalIntegrationState = getIntegration()
+            memory = getVisualMemory()
+            integration = self.gridCompressor(gridCodes)
+            visualPolicy = self.policy_branch(memory)
+            integrationPolicy = self.policy_branch(integration)
+            visualConfidence = (
+                torch.nn.functional.softmax(visualPolicy, -1)
+                .flatten()
+                .topk(2)
+                .values.sum()
+                .item()
+            )
+            integrationConfidence = (
+                torch.nn.functional.softmax(integrationPolicy, -1)
+                .flatten()
+                .topk(2)
+                .values.sum()
+                .item()
+            )
+            if visualConfidence > integrationConfidence:
+                policy = visualPolicy
+            else:
+                policy = integrationPolicy
 
         return (
             policy,

--- a/models/agent_models.py
+++ b/models/agent_models.py
@@ -106,12 +106,6 @@ class PlaceMazeModule(MemoryMazeModule):
             nn.Linear(self.gridSize, self.linearHiddenSize),
             nn.ReLU(),
         )
-        self.gridGate = nn.Sequential(
-            nn.Linear(self.linearHiddenSize, self.linearHiddenSize),
-            nn.ReLU(),
-            nn.Linear(self.linearHiddenSize, 1),
-            nn.Sigmoid(),
-        )
         self.placeCells = nn.Parameter(torch.rand([self.numPlaceCells, 2]), False)
         self.fieldSize = 0.3 / math.sqrt(self.numPlaceCells)
         self.placeEncoder = nn.Linear(self.numPlaceCells, 2 * self.integratorSize)
@@ -241,8 +235,7 @@ class PlaceMazeModule(MemoryMazeModule):
                 lastAgentLocation[:, 0, :], batch[Columns.STATE_IN]["hiddenObs"]
             )
             memory = self._processVisualMemory(vision, initialState)
-            gate = self.gridGate(memory.detach())
-            policyInput = memory * (1 - gate) + self.gridCompressor(gridCodes) * gate
+            policyInput = memory
 
         return (
             policyInput,

--- a/models/agent_models.py
+++ b/models/agent_models.py
@@ -1,10 +1,11 @@
-import torch
-import torch.nn as nn
 import math
-from ray.rllib.core.rl_module.torch.torch_rl_module import TorchRLModule
+
+import torch
 from ray.rllib.core.columns import Columns
 from ray.rllib.core.rl_module.apis import ValueFunctionAPI
+from ray.rllib.core.rl_module.torch.torch_rl_module import TorchRLModule
 from ray.rllib.utils.annotations import override
+from torch import nn
 
 from .simple_conv import SimpleConv
 from .utils import calculatePlace
@@ -112,6 +113,8 @@ class PlaceMazeModule(MemoryMazeModule):
         self.placeEncoderForMemory = nn.Linear(
             self.numPlaceCells, self.linearHiddenSize
         )
+        self.piPolicyPredictor = nn.Linear(self.linearHiddenSize, self.action_space.n)
+        self.piValuePredictor = nn.Linear(self.linearHiddenSize, 1)
 
     @override(TorchRLModule)
     def get_initial_state(self):
@@ -186,7 +189,7 @@ class PlaceMazeModule(MemoryMazeModule):
         memory, _ = self.trajectoryMemory(visionFeatures, initialHidden.unsqueeze(0))
         return memory
 
-    def _processPreHeads(self, batch):
+    def _getPolicyAndValue(self, batch):
         vision, lastAgentLocation, _, action = self._getObsFromBatch(batch)
         gridCodes, projectedPlace, finalIntegrationState = self._pathIntegrate(
             lastAgentLocation[:, 0, :],
@@ -194,18 +197,62 @@ class PlaceMazeModule(MemoryMazeModule):
             batch[Columns.STATE_IN]["hiddenGrid"],
             batch[Columns.STATE_IN]["candidateGrid"],
         )
-        if self.model_config.get("self_localize", False):
-            policyInput = None
-            memory = None
-        else:
+
+        memory = None
+        value = None
+        policy = None
+
+        if not self.model_config.get("self_localize", False):
             initialState = self._getInitialMemory(
                 lastAgentLocation[:, 0, :], batch[Columns.STATE_IN]["hiddenObs"]
             )
             memory = self._processVisualMemory(vision, initialState)
-            policyInput = memory
+            if self.training:
+                integration = self.gridCompressor(gridCodes)
+                controlSelector = (
+                    torch.rand(
+                        [*memory.shape[:2], 1],
+                        device=memory.device,
+                        dtype=torch.float32,
+                    )
+                    < 0.75
+                )
+                policy = torch.where(
+                    controlSelector,
+                    self.policy_branch(memory),
+                    self.piPolicyPredictor(integration),
+                )
+                value = torch.where(
+                    controlSelector,
+                    self.value_branch(memory),
+                    self.piValuePredictor(integration),
+                )
+            else:
+                integration = self.gridCompressor(gridCodes)
+                visualPolicy = self.policy_branch(memory)
+                integrationPolicy = self.policy_branch(integration)
+                visualConfidence = (
+                    torch.nn.functional.softmax(visualPolicy, -1)
+                    .flatten()
+                    .topk(2)
+                    .values.sum()
+                    .item()
+                )
+                integrationConfidence = (
+                    torch.nn.functional.softmax(integrationPolicy, -1)
+                    .flatten()
+                    .topk(2)
+                    .values.sum()
+                    .item()
+                )
+                if visualConfidence > integrationConfidence:
+                    policy = visualPolicy
+                else:
+                    policy = integrationPolicy
 
         return (
-            policyInput,
+            policy,
+            value,
             memory,
             projectedPlace,
             finalIntegrationState,
@@ -214,21 +261,29 @@ class PlaceMazeModule(MemoryMazeModule):
     @override(TorchRLModule)
     def _forward(self, batch, **kwargs):
         _, _, agentLocation, _ = self._getObsFromBatch(batch)
-        policyInput, visualMemory, projectedPlace, finalGrid = self._processPreHeads(
-            batch
+        policy, value, visualMemory, projectedPlace, finalGrid = (
+            self._getPolicyAndValue(batch)
         )
-        if policyInput is None or visualMemory is None:
-            obs = batch["obs"]
-            policy = torch.randn(
-                [*agentLocation.shape[:2], self.action_space.n],
+        obs = batch["obs"]
+        if policy is None:
+            policy = torch.ones(
+                [*obs.shape[:2], self.action_space.n],
                 dtype=torch.float32,
                 device=obs.device,
             )
+
+        if visualMemory is None:
             visualMemory = torch.randn(
-                [*agentLocation.shape[:2], self.linearHiddenSize],
+                [*obs.shape[:2], self.linearHiddenSize],
                 dtype=torch.float32,
                 device=obs.device,
             )
+
+        if value is None:
+            value = torch.ones(
+                [*obs.shape[:2], 1], dtype=torch.float32, device=obs.device
+            )
+
         return {
             Columns.ACTION_DIST_INPUTS: policy,
             Columns.STATE_OUT: {
@@ -236,27 +291,23 @@ class PlaceMazeModule(MemoryMazeModule):
                 "candidateGrid": finalGrid[1].squeeze(0),
                 "hiddenGrid": finalGrid[0].squeeze(0),
             },
-            Columns.EMBEDDINGS: visualMemory,
+            Columns.EMBEDDINGS: value,
             "placeLogit": projectedPlace,
             "placeTarget": calculatePlace(
                 self.placeCells, agentLocation, self.fieldSize
             ),
-            "placeCells": self.placeCells.unsqueeze(0)
-            .unsqueeze(0)
-            .expand([*projectedPlace.shape[:2], self.numPlaceCells, 2]),
         }
 
     @override(ValueFunctionAPI)
     def compute_values(self, batch, embeddings=None):
         if embeddings is None:
-            embeddings, _, _, _ = self._processPreHeads(batch)
+            obs = batch["obs"]
+            _, embeddings, _, _, _ = self._getPolicyAndValue(batch)
             if embeddings is None:
-                embeddings = torch.randn(
-                    [*batch["obs"].shape[:2], self.linearHiddenSize],
-                    dtype=torch.float32,
-                    device=batch["obs"].device,
+                return torch.ones(
+                    [*obs.shape[:2]], dtype=torch.float32, device=obs.device
                 )
-        return self.value_branch(embeddings).squeeze(-1)
+        return embeddings.squeeze(-1)
 
 
 class GPSModule(MemoryMazeModule):

--- a/models/latent_path_module.py
+++ b/models/latent_path_module.py
@@ -59,7 +59,7 @@ class LatentPathModule(PlaceMazeModule):
                 torch.concat([initialMemory.unsqueeze(1), memory], dim=1)
             )
             movements = sequenceProjections[:, 1:, :] - sequenceProjections[:, :-1, :]
-            gridCodes, predictedPlaces, finalGridState = getIntegration(
+            integratedCode, predictedPlaces, finalGridState = getIntegration(
                 sequenceProjections[:, 0, :], movements
             )
             actualPlaces = calculatePlace(
@@ -74,9 +74,11 @@ class LatentPathModule(PlaceMazeModule):
         elif self.model_config.get("pretraining", False):
             policyInput = memory
         else:
-            gridCodes, _, _ = getIntegration()
+            integratedCode, _, _ = getIntegration()
             gate = self.gridGate(memory.detach())
-            policyInput = memory * (1 - gate) + self.gridCompressor(gridCodes) * gate
+            policyInput = (
+                memory * (1 - gate) + self.gridCompressor(integratedCode) * gate
+            )
 
         return (
             policyInput,

--- a/models/latent_path_module.py
+++ b/models/latent_path_module.py
@@ -62,11 +62,9 @@ class LatentPathModule(PlaceMazeModule):
             gridCodes, predictedPlaces, finalGridState = getIntegration(
                 sequenceProjections[:, 0, :], movements
             )
-            accummulatedMovements = torch.cumsum(movements, dim=1)
-            actualPositions = (
-                sequenceProjections[:, 0, :][:, None, :] + accummulatedMovements
+            actualPlaces = calculatePlace(
+                self.placeCells, sequenceProjections[:, 1:, :]
             )
-            actualPlaces = calculatePlace(self.placeCells, actualPositions)
             """
             Doesn't make any sense to path integrate using artificially generated moves
             because the abstract tasks downstream won't have access to a convenient

--- a/models/latent_path_module.py
+++ b/models/latent_path_module.py
@@ -58,6 +58,7 @@ class LatentPathModule(PlaceMazeModule):
             sequenceProjections, reconstructedLatent = self.manifoldProjector(
                 torch.concat([initialMemory.unsqueeze(1), memory], dim=1)
             )
+            reconstructedLatent = reconstructedLatent[:, 1:, :]
             movements = sequenceProjections[:, 1:, :] - sequenceProjections[:, :-1, :]
             integratedCode, predictedPlaces, finalGridState = getIntegration(
                 sequenceProjections[:, 0, :], movements
@@ -86,7 +87,7 @@ class LatentPathModule(PlaceMazeModule):
             actualPlaces,
             finalGridState,
             memory.detach(),
-            reconstructedLatent[:, 1:, :],
+            reconstructedLatent,
             movements,
         )
 

--- a/models/latent_path_module.py
+++ b/models/latent_path_module.py
@@ -1,11 +1,11 @@
 import torch
-import torch.nn as nn
-from ray.rllib.core.rl_module.torch.torch_rl_module import TorchRLModule
 from ray.rllib.core.columns import Columns
 from ray.rllib.core.rl_module.apis import ValueFunctionAPI
+from ray.rllib.core.rl_module.torch.torch_rl_module import TorchRLModule
 from ray.rllib.utils.annotations import override
+from torch import nn
 
-from .agent_models import PlaceMazeModule
+from .agent_models import PathIntegrationWithVisionModule
 from .utils import calculatePlace
 
 
@@ -21,9 +21,9 @@ class ManifoldProjector(nn.Module):
         return projection, reconstructed
 
 
-class LatentPathModule(PlaceMazeModule):
+class LatentPathModule(PathIntegrationWithVisionModule):
     def setup(self):
-        PlaceMazeModule.setup(self)
+        PathIntegrationWithVisionModule.setup(self)
         self.pathIntegrator = nn.LSTM(2, self.integratorSize, batch_first=True)
         self.manifoldProjector = ManifoldProjector(self.linearHiddenSize, 2)
 

--- a/models/latent_path_module.py
+++ b/models/latent_path_module.py
@@ -1,19 +1,15 @@
 import torch
 import torch.nn as nn
-import math
 from ray.rllib.core.rl_module.torch.torch_rl_module import TorchRLModule
 from ray.rllib.core.columns import Columns
 from ray.rllib.core.rl_module.apis import ValueFunctionAPI
 from ray.rllib.utils.annotations import override
 
-from .agent_models import MemoryMazeModule
-from .multi_head_lstm import MultiHeadLSTM
-
-NUM_MODULES = 10
-GRID_MODULE_DIM = 2
+from .agent_models import PlaceMazeModule
+from .utils import calculatePlace
 
 
-class ModuleProjector(nn.Module):
+class ManifoldProjector(nn.Module):
     def __init__(self, inputSize: int, latentSize: int):
         super().__init__()
         self.encoder = nn.Sequential(nn.Linear(inputSize, latentSize), nn.Sigmoid())
@@ -25,229 +21,115 @@ class ModuleProjector(nn.Module):
         return projection, reconstructed
 
 
-class LatentPathModule(MemoryMazeModule):
+class LatentPathModule(PlaceMazeModule):
     def setup(self):
-        MemoryMazeModule.setup(self)
-        self.integratorSize = 128
-        self.gridSize = 512
-        self.numPlaceCells = 32
-        self.mazeSize = self.model_config.get("mazeSize", 31)
-        self.gridCompressor = nn.Sequential(
-            nn.Linear(self.gridSize * NUM_MODULES, self.gridSize),
-            nn.ReLU(),
-            nn.Linear(self.gridSize, self.linearHiddenSize),
-            nn.ReLU(),
-        )
-        self.memoryEncoder = nn.Sequential(
-            nn.Linear(
-                self.linearHiddenSize * 2,
-                self.linearHiddenSize,
-            ),
-            nn.ReLU(),
-            nn.Dropout(),
-        )
-
-        self.moduleProjector = ModuleProjector(
-            self.linearHiddenSize, GRID_MODULE_DIM * NUM_MODULES
-        )
-        self.pathIntegrator = MultiHeadLSTM(
-            GRID_MODULE_DIM, self.integratorSize, NUM_MODULES
-        )
-        self.gridProjectorWeight = nn.Parameter(
-            torch.Tensor(NUM_MODULES, self.integratorSize, self.gridSize)
-        )
-        self.gridProjectorBias = nn.Parameter(torch.Tensor(NUM_MODULES, self.gridSize))
-        self.placeDecoderWeight = nn.Parameter(
-            torch.Tensor(NUM_MODULES, self.gridSize, self.numPlaceCells)
-        )
-        self.placeCells = nn.Parameter(
-            torch.rand([NUM_MODULES, self.numPlaceCells, GRID_MODULE_DIM]),
-            False,
-        )
-        self.fieldSize = 0.3 / math.sqrt(self.numPlaceCells)
-        self.placeEncoderWeight = nn.Parameter(
-            torch.Tensor(NUM_MODULES, self.numPlaceCells, 2 * self.integratorSize)
-        )
-        self.placeEncoderBias = nn.Parameter(
-            torch.Tensor(NUM_MODULES, 2 * self.integratorSize)
-        )
-        stdv = 1.0 / math.sqrt(self.integratorSize)
-        for w in (
-            self.gridProjectorWeight,
-            self.gridProjectorBias,
-            self.placeDecoderWeight,
-            self.placeEncoderWeight,
-            self.placeEncoderBias,
-        ):
-            nn.init.uniform_(w, -stdv, stdv)
-
-    def get_place_activation(self, coordinates: torch.Tensor):
-        with torch.no_grad():
-            originalShape = coordinates.shape[:-2]
-            diff = coordinates.flatten(0, -3).unsqueeze(2) - self.placeCells.unsqueeze(
-                0
-            )
-            dist2 = (diff**2).sum(dim=-1)
-            return torch.nn.functional.softmax(
-                -dist2 / (2 * self.fieldSize**2), dim=-1
-            ).reshape([*originalShape, NUM_MODULES, self.numPlaceCells])
-
-    def _pathIntegrate(
-        self,
-        sequenceProjections: torch.Tensor,
-        initialProjections: torch.Tensor,
-    ):
-        pastPlaceCellActivations = self.get_place_activation(initialProjections)
-        encodedPlace = torch.einsum(
-            "bmp,mpe->bme", pastPlaceCellActivations, self.placeEncoderWeight
-        ) + self.placeEncoderBias.unsqueeze(0)
-        initialHidden = encodedPlace[:, :, : self.integratorSize].contiguous()
-        initialCandidate = encodedPlace[:, :, self.integratorSize :].contiguous()
-        movements = sequenceProjections - torch.concat(
-            [
-                initialProjections[:, None, :, :],
-                sequenceProjections[:, :-1, :, :],
-            ],
-            dim=1,
-        )
-        hiddens, finalStates = self.pathIntegrator.forward(
-            movements, initialHidden, initialCandidate, 20
-        )
-        gridCodes = (
-            torch.einsum("btmd,mdg->btmg", hiddens, self.gridProjectorWeight)
-            + self.gridProjectorBias[None, None, :, :]
-        )
-        predictedPlaceLogit = torch.einsum(
-            "btmg,mgp->btmp",
-            torch.nn.functional.dropout(gridCodes, training=self.training),
-            self.placeDecoderWeight,
-        )
-        return (
-            gridCodes.flatten(2),
-            predictedPlaceLogit,
-            finalStates,
-        )
-
-    @override(TorchRLModule)
-    def get_initial_state(self):
-        return {
-            "hiddenObs": torch.zeros((self.linearHiddenSize,), dtype=torch.float32),
-            "candidateGrid": torch.zeros(
-                (NUM_MODULES * self.integratorSize,), dtype=torch.float32
-            ),
-            "hiddenGrid": torch.zeros(
-                (NUM_MODULES * self.integratorSize,), dtype=torch.float32
-            ),
-        }
+        PlaceMazeModule.setup(self)
+        self.pathIntegrator = nn.LSTM(2, self.integratorSize, batch_first=True)
+        self.manifoldProjector = ManifoldProjector(self.linearHiddenSize, 2)
 
     @override(TorchRLModule)
     def _forward_exploration(self, batch, **kwargs):
-        self.eval()
-        policyFeature, _, _, finalGrid, latents, _ = self._processPreHeads(batch)
-        policy = self.policy_branch(policyFeature)
-        return {
-            Columns.ACTION_DIST_INPUTS: policy,
-            Columns.STATE_OUT: {
-                "hiddenObs": latents[:, -1, :],
-                "candidateGrid": finalGrid[1].squeeze(0),
-                "hiddenGrid": finalGrid[0].squeeze(0),
-            },
-            "actualLatents": latents,
-        }
-
-    def _getPolicyInput(self, features, gridCode):
-        with torch.no_grad():
-            gridWithoutGrad = torch.Tensor(gridCode)
-            featuresWithoutGrad = torch.Tensor(features)
-        compressedGrid = self.gridCompressor.forward(gridWithoutGrad)
-        encodedMemory = self.memoryEncoder(
-            torch.concat([featuresWithoutGrad, compressedGrid], dim=2)
-        )
-        return encodedMemory
+        return self._forward(batch, **kwargs)
 
     def _processPreHeads(self, batch):
-        initialLatent = batch[Columns.STATE_IN]["hiddenObs"]
-        latents, _ = super()._processPreHeads(batch)
-        with torch.no_grad():
-            latentsWithoutGrad = torch.Tensor(latents)
-            initialLatentsWithoutGrad = torch.Tensor(initialLatent)
-        if self.model_config.get("self_localize"):
-            sequenceProjections, reconstructedLatent = self.moduleProjector.forward(
-                latentsWithoutGrad
+        vision, lastAgentLocation, _, _ = self._getObsFromBatch(batch)
+        initialMemory = self._getInitialMemory(
+            lastAgentLocation[:, 0, :], batch[Columns.STATE_IN]["hiddenObs"]
+        )
+
+        def getIntegration(startingCoordinate: torch.Tensor, movement: torch.Tensor):
+            return self._pathIntegrate(
+                startingCoordinate,
+                movement,
+                batch[Columns.STATE_IN]["hiddenGrid"],
+                batch[Columns.STATE_IN]["candidateGrid"],
             )
-            pastProjections, _ = self.moduleProjector.forward(initialLatentsWithoutGrad)
-            with torch.no_grad():
-                sequenceProjections = sequenceProjections.reshape(
-                    [*latents.shape[:2], NUM_MODULES, GRID_MODULE_DIM]
-                )
-                pastProjections = pastProjections.reshape(
-                    [initialLatent.shape[0], NUM_MODULES, GRID_MODULE_DIM]
-                )
-            gridCode, predictedPlaces, finalGrid = self._pathIntegrate(
-                sequenceProjections, pastProjections
+
+        memory = self._processVisualMemory(vision, initialMemory)
+
+        predictedPlaces = None
+        actualPlaces = None
+        finalGridState = None
+        reconstructedLatent = None
+        movements = None
+
+        if self.model_config.get("self_localize", False):
+            memory = memory.detach()
+            sequenceProjections, reconstructedLatent = self.manifoldProjector(
+                torch.concat([initialMemory.unsqueeze(1), memory], dim=1)
             )
-            actualPlaces = self.get_place_activation(sequenceProjections)
+            movements = sequenceProjections[:, 1:, :] - sequenceProjections[:, :-1, :]
+            gridCodes, predictedPlaces, finalGridState = getIntegration(
+                sequenceProjections[:, 0, :], movements
+            )
+            accummulatedMovements = torch.cumsum(movements, dim=1)
+            actualPositions = (
+                sequenceProjections[:, 0, :][:, None, :] + accummulatedMovements
+            )
+            actualPlaces = calculatePlace(self.placeCells, actualPositions)
+            """
+            Doesn't make any sense to path integrate using artificially generated moves
+            because the abstract tasks downstream won't have access to a convenient
+            manifold to navigate smoothly in.
+            """
+            policyInput = memory
+        elif self.model_config.get("pretraining", False):
+            policyInput = memory
         else:
-            batchShape = latents.shape[:2]
-            gridCode = torch.zeros(
-                [*batchShape[:2], NUM_MODULES * self.gridSize],
-                dtype=torch.float32,
-                device=latents.device,
-            )
-            finalGrid = torch.zeros(
-                [1, batchShape[0], NUM_MODULES * self.integratorSize],
-                dtype=torch.float32,
-                device=latents.device,
-            )
-            finalGrid = (finalGrid, finalGrid)
-            predictedPlaces = torch.zeros(
-                [*batchShape, NUM_MODULES, self.numPlaceCells],
-                dtype=torch.float32,
-                device=latents.device,
-            )
-            actualPlaces = predictedPlaces
-            reconstructedLatent = torch.zeros(
-                latents.shape,
-                dtype=torch.float32,
-                device=latents.device,
-            )
+            gridCodes, _, _ = getIntegration()
+            gate = self.gridGate(memory.detach())
+            policyInput = memory * (1 - gate) + self.gridCompressor(gridCodes) * gate
+
         return (
-            self._getPolicyInput(latents, torch.nn.functional.dropout(gridCode)),
+            policyInput,
             predictedPlaces,
-            actualPlaces,
-            finalGrid,
-            latentsWithoutGrad,
-            reconstructedLatent,
+            actualPlaces.detach(),
+            finalGridState,
+            memory.detach(),
+            reconstructedLatent[:, 1:, :],
+            movements,
         )
 
     @override(TorchRLModule)
     def _forward(self, batch, **kwargs):
-        self.train()
         (
             policyFeature,
             predictedPlaces,
             actualPlaces,
             finalGrid,
-            latents,
+            memory,
             reconstructedLatent,
+            movements,
         ) = self._processPreHeads(batch)
         policy = self.policy_branch(policyFeature)
-        return {
+        output = {
             Columns.ACTION_DIST_INPUTS: policy,
             Columns.STATE_OUT: {
-                "hiddenObs": latents[:, -1, :],
-                "candidateGrid": finalGrid[1].squeeze(0),
-                "hiddenGrid": finalGrid[0].squeeze(0),
+                "hiddenObs": memory[:, -1, :],
+                "candidateGrid": finalGrid[1].squeeze(0)
+                if finalGrid
+                else batch[Columns.STATE_IN]["candidateGrid"],
+                "hiddenGrid": finalGrid[0].squeeze(0)
+                if finalGrid
+                else batch[Columns.STATE_IN]["hiddenGrid"],
             },
             Columns.EMBEDDINGS: policyFeature,
-            "placeLogit": predictedPlaces,
-            "placeTarget": actualPlaces,
-            "reconstructedLatents": reconstructedLatent,
-            "actualLatents": latents,
         }
+        if predictedPlaces is not None:
+            output["placeLogit"] = predictedPlaces
+            output["placeTarget"] = actualPlaces
+
+        if reconstructedLatent is not None:
+            output["reconstructedLatents"] = reconstructedLatent
+            output["actualLatents"] = memory
+
+        if movements is not None:
+            output["movements"] = movements
+
+        return output
 
     @override(ValueFunctionAPI)
     def compute_values(self, batch, embeddings=None):
         if embeddings is None:
-            embeddings, _, _, _, _, _ = self._processPreHeads(batch)
+            embeddings, _, _, _, _, _, _ = self._processPreHeads(batch)
         return self.value_branch(embeddings).squeeze(-1)

--- a/models/latent_path_module.py
+++ b/models/latent_path_module.py
@@ -64,7 +64,7 @@ class LatentPathModule(PlaceMazeModule):
             )
             actualPlaces = calculatePlace(
                 self.placeCells, sequenceProjections[:, 1:, :]
-            )
+            ).detach()
             """
             Doesn't make any sense to path integrate using artificially generated moves
             because the abstract tasks downstream won't have access to a convenient
@@ -83,7 +83,7 @@ class LatentPathModule(PlaceMazeModule):
         return (
             policyInput,
             predictedPlaces,
-            actualPlaces.detach(),
+            actualPlaces,
             finalGridState,
             memory.detach(),
             reconstructedLatent[:, 1:, :],

--- a/models/pure_code_module.py
+++ b/models/pure_code_module.py
@@ -1,12 +1,12 @@
-import torch.nn as nn
 from ray.rllib.core.columns import Columns
+from torch import nn
 
-from .agent_models import PlaceMazeModule
+from .agent_models import PathIntegrationWithVisionModule
 
 
-class PureCodeModule(PlaceMazeModule):
+class PureCodeModule(PathIntegrationWithVisionModule):
     def setup(self):
-        PlaceMazeModule.setup(self)
+        PathIntegrationWithVisionModule.setup(self)
         self.prePolicyEncoder = nn.Sequential(
             nn.Linear(self.gridSize, self.linearHiddenSize),
             nn.ReLU(),

--- a/models/utils.py
+++ b/models/utils.py
@@ -16,4 +16,4 @@ def calculatePlace(
         normalized_activations = torch.nn.functional.softmax(
             unnormalized_activations, dim=1
         )
-        return normalized_activations.reshape([*agentLocationShape[:2], numPlaceCells])
+        return normalized_activations.reshape([*agentLocationShape[:-1], numPlaceCells])

--- a/rate_map.py
+++ b/rate_map.py
@@ -1,20 +1,22 @@
-from ray.rllib.core.columns import Columns
-from ray.rllib.utils.numpy import convert_to_numpy
-from ray.rllib.core.rl_module.rl_module import RLModule
-from ray.rllib.core import DEFAULT_MODULE_ID
-import matplotlib.pyplot as plt
-import matplotlib
 import random
+
+import matplotlib
+import matplotlib.pyplot as plt
+from ray.rllib.core import DEFAULT_MODULE_ID
+from ray.rllib.core.columns import Columns
+from ray.rllib.core.rl_module.rl_module import RLModule
+from ray.rllib.utils.numpy import convert_to_numpy
 
 matplotlib.use("Agg")
 
+import argparse
+import os
+
 import numpy as np
 import torch
-import os
-import argparse
 
-from environments import PlaceMazeEnv
 import models
+from environments import PlaceMazeEnv
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--expName", type=str, default="default_exp")
@@ -48,7 +50,9 @@ def generateRatemap(mazeSize: int, modulePath: str, expName: str):
             "mazeSize": mazeSize,
         }
     )
-    module: models.PlaceMazeModule = RLModule.from_checkpoint(modulePath)
+    module: models.PathIntegrationWithVisionModule = RLModule.from_checkpoint(
+        modulePath
+    )
     obs, _ = env.reset()
     steps = 0
     occupancyCounter = []
@@ -73,7 +77,7 @@ def generateRatemap(mazeSize: int, modulePath: str, expName: str):
         }
         rl_module_out = module.forward_exploration(batched_obs)
         action = getMoveByCoverage(env, occupancyCounter)
-        obs, reward, done, truncated, info = env.step(action)
+        obs, _, done, truncated, _ = env.step(action)
         done = done or truncated
         steps += 1
         occupancyCounter[env._agentLocation[0]][env._agentLocation[1]] += 1

--- a/train.py
+++ b/train.py
@@ -34,7 +34,8 @@ parser.add_argument("--gps", action="store_true")
 parser.add_argument("--latentPath", action="store_true")
 parser.add_argument("--pretraining", action="store_true")
 parser.add_argument("--pureCode", action="store_true")
-parser.add_argument("--perturb", action="store_true")
+parser.add_argument("--entropy", type=float, default=0.1)
+parser.add_argument("--visionPolicy", action="store_true")
 args = parser.parse_args()
 
 if args.pretraining:
@@ -116,6 +117,7 @@ if __name__ == "__main__":
                     "mazeSize": mazeSize,
                     "self_localize": args.selfLocalize,
                     "pretraining": args.pretraining,
+                    "visionPolicy": args.visionPolicy,
                 },
             ),
         )
@@ -127,7 +129,7 @@ if __name__ == "__main__":
         )
         .training(
             lr=args.lr,
-            entropy_coeff=[[0, 0.1], [8000000, 0.1], [8000001, 0.01]],
+            entropy_coeff=args.entropy,
         )
     )
     if usesGrid():

--- a/train.py
+++ b/train.py
@@ -1,19 +1,17 @@
-import pickle
-import os
-import torch
-import numpy as np
 import argparse
-
+import os
+import pickle
 from datetime import datetime
+
+import numpy as np
+import torch
 from ray.rllib.algorithms.ppo import PPOConfig
 from ray.rllib.core.rl_module.rl_module import RLModuleSpec
 
-
-from maze import generateMaze, getMazeDebugString
+import models
 from environments import MazeEnv, PlaceMazeEnv, SelfLocalizeEnv
 from learners.ppo_grid_learner import PPOTorchLearnerWithSelfPredLoss
-import models  # noqa: F401
-
+from maze import generateMaze, getMazeDebugString
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--mazeSize", type=int, default=30)
@@ -72,7 +70,7 @@ if __name__ == "__main__":
         getMazeDebugString(maze)
 
     if usesGrid():
-        module = models.PlaceMazeModule
+        module = models.PathIntegrationWithVisionModule
         if args.latentPath:
             module = models.LatentPathModule
         elif args.pureCode:
@@ -155,7 +153,7 @@ if __name__ == "__main__":
                 print(
                     f"Iteration {i + 1}",
                     " - ",
-                    str(datetime.now())[:-7],
+                    str(datetime.now(tz=datetime.tzinfo))[:-7],
                 )
                 if args.selfLocalize:
                     predictionError = np.round(

--- a/train.py
+++ b/train.py
@@ -97,7 +97,6 @@ if __name__ == "__main__":
         "memoryLen": args.memoryLen,
         "mazeSize": mazeSize,
         "debugging": args.debug,
-        "perturb": args.perturb,
     }
 
     agentConfig = (
@@ -155,7 +154,7 @@ if __name__ == "__main__":
                 print(
                     f"Iteration {i + 1}",
                     " - ",
-                    str(datetime.now(tz=datetime.tzinfo))[:-7],
+                    str(datetime.now())[:-7],  # noqa: DTZ005
                 )
                 if args.selfLocalize:
                     predictionError = np.round(

--- a/train.py
+++ b/train.py
@@ -127,9 +127,7 @@ if __name__ == "__main__":
         )
         .training(
             lr=args.lr,
-            entropy_coeff=[[0, 0.1], [8000000, 0.1], [8000001, 0.01]]
-            if not args.grid
-            else 0.01,
+            entropy_coeff=[[0, 0.1], [8000000, 0.1], [8000001, 0.01]],
         )
     )
     if usesGrid():

--- a/train.py
+++ b/train.py
@@ -9,8 +9,8 @@ from ray.rllib.algorithms.ppo import PPOConfig
 from ray.rllib.core.rl_module.rl_module import RLModuleSpec
 
 
-from maze import generateMaze, getMazeDebugString, generateMazeWithOfflimit
-from environments import MazeEnv, FoggedMazeEnv, PlaceMazeEnv, SelfLocalizeEnv
+from maze import generateMaze, getMazeDebugString
+from environments import MazeEnv, PlaceMazeEnv, SelfLocalizeEnv
 from learners.ppo_grid_learner import PPOTorchLearnerWithSelfPredLoss
 import models  # noqa: F401
 
@@ -34,9 +34,12 @@ parser.add_argument("--memoryLen", type=int, default=20)
 parser.add_argument("--debug", action="store_true")
 parser.add_argument("--gps", action="store_true")
 parser.add_argument("--latentPath", action="store_true")
-parser.add_argument("--offlimit", action="store_true")
+parser.add_argument("--pretraining", action="store_true")
 parser.add_argument("--pureCode", action="store_true")
 args = parser.parse_args()
+
+if args.pretraining:
+    args.latentPath = True
 
 
 def usesGrid():
@@ -50,9 +53,7 @@ if __name__ == "__main__":
     visionRange = 4
     maze = None
 
-    if args.offlimit:
-        maze = generateMazeWithOfflimit(mazeSize)
-    elif args.selfLocalize:
+    if args.selfLocalize:
         maze = generateMaze(mazeSize, 0)
     elif not args.randomMaze:
         if not os.path.exists(mazesPath):
@@ -82,11 +83,9 @@ if __name__ == "__main__":
     else:
         module = models.SimpleMazeModule
 
-    if args.latentPath:
-        env = FoggedMazeEnv
-    elif args.selfLocalize:
+    if args.selfLocalize:
         env = SelfLocalizeEnv
-    elif args.grid or args.gps or args.fogged:
+    elif usesGrid() or args.gps or args.fogged:
         env = PlaceMazeEnv
     else:
         env = MazeEnv
@@ -116,6 +115,7 @@ if __name__ == "__main__":
                     "max_seq_len": args.memoryLen,
                     "mazeSize": mazeSize,
                     "self_localize": args.selfLocalize,
+                    "pretraining": args.pretraining,
                 },
             ),
         )
@@ -172,6 +172,11 @@ if __name__ == "__main__":
                             2,
                         )
                         print("Reconstruction Loss:", reconstructionLoss)
+                        movementLoss = np.round(
+                            result["learners"]["default_policy"]["movement_loss"],
+                            2,
+                        )
+                        print("Movement Loss:", movementLoss)
                     # placeBias = np.round(
                     #     result["learners"]["default_policy"]["place_bias"], 2
                     # )

--- a/train_pi.sh
+++ b/train_pi.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-python train.py "$1" "$2" --selfLocalize --numLearn 3000
-python train.py "$1" "$2" --grid

--- a/train_pi_with_vision.sh
+++ b/train_pi_with_vision.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+python train.py "$1" "$2" --selfLocalize
+python train.py "$1" "$2" --grid --visionPolicy --numLearn 2000
+python train.py "$1" "$2" --grid --visionPolicy --numLearn 1000 --entropy 0.01
+python train.py "$1" "$2" --grid --numLearn 500
+python train.py "$1" "$2" --grid --numLearn 500 --entropy 0.01


### PR DESCRIPTION
### Latent PI Changes
- Repurposed the old latent path integration code to focus only on 2D manifold. This allows it to inherit many functions from simpler modules.
- Enforce a loss on the movements between states in the manifold so that their distances are roughly the same.

### Physical PI Changes
- Instead of learning a single policy, learn two independent policies that will not be mixed, more sophisticated logic for using one or the other
- Dedicated script to run perturbation experiments
- Dedicated bash script to train the path integration + vision module end-to-end

### Side Note
Because of the architecture update, training the path integration + vision module is essentially the same as training both the pure code and place cell control. They could potentially be removed.